### PR TITLE
Claude/work on copy 01 wq zj66q5 ep7 rh ct xefhzvz

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
 
   # npm (frontend)
   - package-ecosystem: "npm"
-    directory: "/frontend"
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,9 +60,9 @@ jobs:
             ENVIRONMENT=staging
             LOG_LEVEL=DEBUG
           secrets: |
-            DATABASE_URL=database-url-staging:latest
-            REDIS_URL=redis-url-staging:latest
-            SECRET_KEY=app-secret-key-staging:latest
+            DATABASE_URL=database-url:latest
+            REDIS_URL=redis-url:latest
+            SECRET_KEY=app-secret-key:latest
             OPENAI_API_KEY=openai-api-key:latest
           flags: |
             --allow-unauthenticated
@@ -135,9 +135,9 @@ jobs:
             ENVIRONMENT=production
             LOG_LEVEL=INFO
           secrets: |
-            DATABASE_URL=database-url-production:latest
-            REDIS_URL=redis-url-production:latest
-            SECRET_KEY=app-secret-key-production:latest
+            DATABASE_URL=database-url:latest
+            REDIS_URL=redis-url:latest
+            SECRET_KEY=app-secret-key:latest
             OPENAI_API_KEY=openai-api-key:latest
           flags: |
             --allow-unauthenticated


### PR DESCRIPTION
## Summary
- Fix dependabot npm path - package.json is at root, not /frontend
- Simplify deployment by using shared GCP secrets for all environments (database-url, redis-url, app-secret-key)

## Changes
- `.github/dependabot.yml`: Updated npm directory from `/frontend` to `/`
- `.github/workflows/deploy.yml`: Changed from environment-specific secrets to shared secrets

## Test plan
- [ ] Verify dependabot can find package.json at root
- [ ] Deploy should succeed with shared secret names

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Point Dependabot npm to repo root and unify Cloud Run deployment secrets to shared names for all environments.
> 
> - **CI/CD**:
>   - **Dependabot**: Point npm updates to repo root by setting `directory: "/"` in `.github/dependabot.yml`.
>   - **Cloud Run deploy**: In `.github/workflows/deploy.yml`, replace env-specific secrets with shared names for both staging and production:
>     - `DATABASE_URL`, `REDIS_URL`, `SECRET_KEY` now reference `*-:latest` without environment suffixes; keep `OPENAI_API_KEY` unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cf605c769251cd426d32610db60733bd4efd310. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->