### PR TITLE
 Add database dependencies for Cloud Run migrations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,8 @@ fastapi>=0.109.0
 uvicorn[standard]>=0.27.0
 pydantic>=2.5.0
 gunicorn>=21.2.0
+
+# Database
+sqlalchemy>=2.0.0
+alembic>=1.13.0
+psycopg2-binary>=2.9.0


### PR DESCRIPTION
## Summary
- Add sqlalchemy, alembic, and psycopg2-binary to requirements.txt
- Enables running database migrations via Cloud Run jobs
- Fixes deployment failure where `copy-that-migrations-production` job couldn't execute

## Test plan
- [ ] Merge PR and verify build workflow completes successfully
- [ ] Create Cloud Run migration jobs in GCP Console:
  - `copy-that-migrations-production`
  - `copy-that-migrations-staging`
- [ ] Trigger deployment and verify migration job executes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add sqlalchemy, alembic, and psycopg2-binary to requirements to enable database migrations on Cloud Run.
> 
> - **Dependencies**:
>   - Add `sqlalchemy`, `alembic`, and `psycopg2-binary` to `requirements.txt` to support database migrations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 857c2c192dce27992fb74161bccf1a05cc834c7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->