### PR TITLE
Add alembic files to Docker image for migrations

### DIFF
--- a/Dockerfile.cloudrun
+++ b/Dockerfile.cloudrun
@@ -13,6 +13,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy source code
 COPY src ./src
 
+# Copy alembic for database migrations
+COPY alembic.ini .
+COPY alembic ./alembic
+
 # Expose port (Cloud Run sets PORT env var)
 ENV PORT=8080
 EXPOSE 8080


### PR DESCRIPTION
Copy alembic.ini and alembic directory so Cloud Run jobs can find the migration scripts and configuration.