### PR TITLE
Fix Boolean server_default in migration for PostgreSQL

### DIFF
--- a/alembic/versions/2025_11_20_006_add_session_and_library_models.py
+++ b/alembic/versions/2025_11_20_006_add_session_and_library_models.py
@@ -44,7 +44,7 @@ def upgrade() -> None:
         sa.Column("token_type", sa.String(length=50), nullable=False),
         sa.Column("name", sa.String(length=255), nullable=True),
         sa.Column("statistics", sa.Text(), nullable=True),
-        sa.Column("is_curated", sa.Boolean(), nullable=False, server_default="0"),
+        sa.Column("is_curated", sa.Boolean(), nullable=False, server_default="false"),
         sa.Column("curation_notes", sa.Text(), nullable=True),
         sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
         sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),


### PR DESCRIPTION
## Summary
- Fix migration failure in production by correcting invalid Boolean column default value
- Change `server_default="0"` to `server_default="false"` for `is_curated` column in `token_libraries` table

## Problem
The Cloud Run migration job `copy-that-migrations-production` failed during execution. PostgreSQL requires boolean literals (`"true"`/`"false"`) for boolean column defaults, not numeric strings like `"0"`.

**Error location:** `alembic/versions/2025_11_20_006_add_session_and_library_models.py:47`

## Test plan
- [ ] CI passes with updated migration
- [ ] Re-run production migration job: `gcloud run jobs execute copy-that-migrations-production --region=us-central1 --wait`
- [ ] Verify `token_libraries` table is created with correct `is_curated` default
