### PR TITLE
Claude/fix readme badges 01 ks k2 mup ac z3m cgxc8n8 nkp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           flags: unittests
           name: codecov-umbrella

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
   deploy-staging:
     name: Deploy to Staging
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/develop' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging')
+    if: (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'develop') || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging')
     environment:
       name: staging
       url: ${{ steps.deploy.outputs.url }}
@@ -105,7 +105,7 @@ jobs:
   deploy-production:
     name: Deploy to Production
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
+    if: (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production')
     environment:
       name: production
       url: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
## Summary

- Fix Codecov badge not updating by adding authentication token
- Fix Deploy badge not updating by correcting workflow_run branch conditions

## Changes

### 1. Codecov Authentication (`ci.yml`)
Added `token: ${{ secrets.CODECOV_TOKEN }}` to the codecov-action. Without this, coverage uploads were failing silently and the badge wasn't updating.

### 2. Deploy Workflow Conditions (`deploy.yml`)
Changed branch detection from `github.ref` to `github.event.workflow_run.head_branch`:

| Before | After |
|--------|-------|
| `github.ref == 'refs/heads/develop'` | `github.event.workflow_run.head_branch == 'develop'` |
| `github.ref == 'refs/heads/main'` | `github.event.workflow_run.head_branch == 'main'` |

In `workflow_run` context, `github.ref` refers to the default branch, not the branch that triggered the build. This was preventing deploy jobs from ever running.

## Test Plan

- [ ] Verify `CODECOV_TOKEN` secret is set in repository settings
- [ ] Merge to main and confirm deploy workflow triggers after build completes
- [ ] Check Codecov badge updates after CI runs
- [ ] Check Deploy badge updates after successful deployment