### PR TITLE
feat: add multi-token streaming, snapshots, and spacing persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased (v0.4.2)
+
+### Validation & Quality
+- Accept hex/rgb/hsl color formats; custom validation rule hooks.
+- Palette harmony scoring with ColorAide utilities; semantic naming recommendations.
+
+### Generator & Tooling
+- Added Figma export template and CLI helper (`scripts/generate_figma_tokens.py`).
+- Added token diff utility for comparing generations.
+- Improved color HTML demo (filters for WCAG/harmony, semantic metadata); spacing demo retained rich visualization.
+
+### Docs
+- Added session-0-6 cleanup summary and planning/reference review notes.
+
 ## v0.4.1 — 2025-11-23
 
 ### Complete Pipeline Architecture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,18 @@ All notable changes to this project will be documented in this file.
 - **Type safety**: Full mypy type compatibility across Python versions
 
 ## Unreleased
+### Frontend / UX
+- SSE multi-extract streaming for color + spacing (CV-first, AI-second) on the main page; spacing tokens now load with projects and snapshots.
+- Added snapshot load (latest snapshot) in UI; spacing prominence/base-unit/scale and color extractor/model/histogram significance now displayed.
+
+### Backend
+- Added spacing_tokens table and project_snapshots table with persistence from multi-extract.
+- New batch endpoints: `/api/v1/colors/batch` and enhanced `/api/v1/spacing/batch-extract` (CV+AI merge).
+- Snapshot APIs: list and fetch project snapshots.
+- CV spacing extractor returns prominence and base unit/scale metadata for UI.
+
+### Docs
+- Updated parity plans and architecture docs for color/spacing; README notes recent SSE/snapshot/batch additions.
 
 ### Pipeline Foundation
 - **Pipeline interfaces**: Added `copy_that.pipeline` module with core types and interfaces for multi-agent token extraction

--- a/README.md
+++ b/README.md
@@ -40,18 +40,20 @@ Copy That is a modern token extraction and generation platform built with:
 - **Cloud-Native** - Designed for GCP Cloud Run
 - **AI-Powered** - Claude Sonnet 4.5 for intelligent extraction
 
-## 🎯 Current Status (v0.4.1)
+## 🎯 Current Status (v0.4.2-dev)
 
-**Ready:** Full pipeline architecture implemented for multi-token extraction with colors as first token type.
-**Frontend:** Educational UI with TokenGrid/Inspector/Playground + Minimalist design guide.
-**Backend:** Complete pipeline system (preprocessing → extraction → aggregation → validation → generation) with W3C Design Tokens support.
+**Ready:** Full pipeline architecture implemented for colors and spacing (multi-token extraction).
+**Frontend:** Educational UI with TokenGrid/Inspector/Playground + interactive color/spacing demos.
+**Backend:** Complete pipeline system (preprocess → extract → aggregate → validate → generate) with W3C Design Tokens support and Figma export.
 
 ### ✅ What's Included
 - **Pipeline Architecture**: 5-stage pipeline (Preprocessing, Extraction, Aggregation, Validation, Generation)
 - **Color Extraction**: Claude Sonnet 4.5 + ColorAide, Delta-E deduplication, provenance tracking
+- **Spacing Extraction**: Hybrid CV/AI (spacing models/utils, aggregation, generators, API)
 - **Tool Use Integration**: Structured output via Claude Tool Use (no regex parsing)
 - **Security**: SSRF protection, async HTTP with httpx, image validation with magic bytes
-- **Output Formats**: W3C Design Tokens, CSS Custom Properties, React themes, Tailwind configs
+- **Output Formats**: W3C Design Tokens, CSS Custom Properties, React themes, Tailwind configs, Figma JSON
+- **Demos**: Rich HTML/React demos for colors and spacing (WCAG, harmony, provenance, grid alignment)
 - **Sessions & Libraries**: Batch extraction, stats, curation (roles), multi-format exports
 - **Frontend**: Responsive UI with Zustand store; TokenGrid, Inspector, Playground components
 - **Tests**: Comprehensive unit/integration/e2e tests with 95%+ coverage on pipeline components

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Copy That is a modern token extraction and generation platform built with:
 - **W3C Design Tokens** - Industry-standard token schema
 - **Domain-Driven Design** - Clean, maintainable architecture
 - **Cloud-Native** - Designed for GCP Cloud Run
+
+### Recent additions
+- **SSE multi-extract** (`/api/v1/extract/stream`): CV-first, AI-second streaming for color + spacing with project persistence.
+- **Snapshots**: Immutable project snapshots of color/spacing tokens (`/api/v1/projects/{id}/snapshots`).
+- **Batch endpoints**: Color batch (`/api/v1/colors/batch`) and spacing batch with CV+AI merge.
+- **Spacing persistence**: First-class `spacing_tokens` table and project load of spacing tokens.
 - **AI-Powered** - Claude Sonnet 4.5 for intelligent extraction
 
 ## 🎯 Current Status (v0.4.2-dev)

--- a/alembic/versions/2025_11_24_add_project_snapshots.py
+++ b/alembic/versions/2025_11_24_add_project_snapshots.py
@@ -1,0 +1,37 @@
+"""add project snapshots table
+
+Revision ID: 2025_11_24_add_project_snapshots
+Revises: 2025_11_24_add_spacing_tokens
+Create Date: 2025-11-24
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2025_11_24_add_project_snapshots"
+down_revision = "2025_11_24_add_spacing_tokens"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    tables = inspector.get_table_names()
+    if "project_snapshots" in tables:
+        return
+    op.create_table(
+        "project_snapshots",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("project_id", sa.Integer(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("data", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_project_snapshots_project_id", table_name="project_snapshots")
+    op.drop_table("project_snapshots")

--- a/alembic/versions/2025_11_24_add_spacing_tokens.py
+++ b/alembic/versions/2025_11_24_add_spacing_tokens.py
@@ -1,0 +1,53 @@
+"""add spacing tokens table
+
+Revision ID: 2025_11_24_add_spacing_tokens
+Revises: 2025_11_22_002_add_user_authentication
+Create Date: 2025-11-24
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "2025_11_24_add_spacing_tokens"
+down_revision = "2025_11_22_002"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create table if it does not already exist
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if "spacing_tokens" not in inspector.get_table_names():
+        op.create_table(
+            "spacing_tokens",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("project_id", sa.Integer(), nullable=False, index=True),
+            sa.Column("extraction_job_id", sa.Integer(), nullable=True),
+            sa.Column("value_px", sa.Integer(), nullable=False),
+            sa.Column("name", sa.String(length=255), nullable=False),
+            sa.Column("semantic_role", sa.String(length=100), nullable=True),
+            sa.Column("spacing_type", sa.String(length=50), nullable=True),
+            sa.Column("category", sa.String(length=50), nullable=True),
+            sa.Column("confidence", sa.Float(), nullable=False, server_default="0"),
+            sa.Column("usage", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        )
+    # Create index if missing
+    indexes = (
+        {ix["name"] for ix in inspector.get_indexes("spacing_tokens")}
+        if "spacing_tokens" in inspector.get_table_names()
+        else set()
+    )
+    if (
+        "ix_spacing_tokens_project_id" not in indexes
+        and "spacing_tokens" in inspector.get_table_names()
+    ):
+        op.create_index("ix_spacing_tokens_project_id", "spacing_tokens", ["project_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_spacing_tokens_project_id", table_name="spacing_tokens")
+    op.drop_table("spacing_tokens")

--- a/docs/architecture/2025-11-24_architecture_parity_check.md
+++ b/docs/architecture/2025-11-24_architecture_parity_check.md
@@ -1,0 +1,123 @@
+# Architecture Parity Check – Copy That vs. Strategic Vision vs. Copy-This-Archive
+_Date: 2025-11-24 (updated)_
+
+## Scope
+- **Current app (Copy That)**: repo `copy-that` (advanced color/spacing demo, CV-first + AI refinement, project save/load with image + spacing metadata).
+- **Target**: `docs/architecture/STRATEGIC_VISION_AND_ARCHITECTURE.md` (multi-token, governed, observable pipeline + exports).
+- **Archive**: `copy-this-archive` (CV-first, richer token coverage and extractors; weaker architecture/governance).
+
+---
+
+## Parity Checklist (Current vs Target vs Archive)
+- Token coverage
+  - [x] Color (CV+AI, saves to DB)
+  - [x] Spacing (CV+AI, returned; persistence as metadata only)
+  - [ ] Typography
+  - [ ] Shadows / radius / borders / animation
+  - [ ] Cross-token variants/density (only in code, not wired)
+- Pipeline orchestration
+  - [~] Orchestrator code present; front-end simulates stages; CV-first, AI-second for color/spacing
+  - [ ] Real multi-token orchestrated runs with per-run state/metrics
+  - [ ] Streaming SSE by token type (partial: synchronous CV+AI merge)
+- Persistence & snapshots
+  - [x] Projects table; color tokens persisted; image + spacing tokens stored in description JSON
+  - [ ] Spacing/typography DB tables; versioned snapshots; rollback
+  - [ ] Project “snapshot” entity to store all token types atomically
+- Project/Session UX
+  - [x] Project create/load/save (disabled until tokens exist)
+  - [ ] Session dashboard, run history, ownership enforcement
+  - [ ] Batch/multi-image runs
+- Validation
+  - [~] WCAG/harmony for color; semantic names
+  - [ ] Validation for spacing/typography/shadows; design rulesets
+- Generation/Exports
+  - [ ] W3C/CSS/React/Tailwind/Figma/diff UI (generators exist but not exposed)
+- Auth/Governance
+  - [ ] AuthN/Z, ACL, audit, rate limits (owner_id column only)
+- Observability
+  - [ ] Per-run metrics/logs dashboards; current /metrics only
+- UI demos
+  - [x] Advanced color/spacing page; light theme
+  - [ ] Unified homepage + demos for typography/shadow/animation
+- Fail-safety
+  - [x] CV fallback for color/spacing; AI errors degrade gracefully
+  - [ ] Token-level retry/backoff across all types
+
+Legend: [x] done, [~] partial, [ ] missing.
+
+---
+
+## Comparison Table (Deeper)
+| Area | Current (Copy That) | Target (Strategic Vision) | Archive (copy-this-archive) | Gaps / Actions |
+| --- | --- | --- | --- | --- |
+| Token Types | Color (CV+AI), Spacing (CV+AI, no DB table), no typography/shadow | Full set: color, spacing, typography, shadow, radius, animation, states | Color, spacing, typography CV/AI pipelines present | Add DB + endpoints for spacing/typography/shadow; port archive extractors; single token schema with per-type adapters |
+| Ingestion | Single-image upload (base64/URL); no batch | Multi-modal (img/video/audio/doc), batch | Image upload + some batch hooks | Add batch ingest and modal detection; reuse archive batch planner |
+| Preprocess | Minimal; implicit in UI | Robust CV/ML preprocess per modality | CV preprocess (opencv/pillow) available | Port archive preprocess modules; expose per-token preprocess configs |
+| Extract (fast path) | CV color (Pillow+coloraide), CV spacing (OpenCV gaps); AI refinement via OpenAI | CV-first for all types; AI refinement optional/streaming | CV-first implemented for color/spacing/typography | Port CV typography/shadow; add token-type registry; stream CV immediately |
+| Extract (AI path) | OpenAI vision; merges CV+AI; spacing AI via OpenAI | AI enrichment per type; tiered models | Claude/OpenAI; prompt-rich; tiered | Keep OpenAI default; add prompt+JSON per token; tiered models; streaming SSE |
+| Aggregation/Provenance | Basic dedup for color; no provenance graph | Cross-token dedup, provenance, lineage | Provenance light | Add provenance map per token id; merge policies (cv→ai→user) |
+| Validation | WCAG/harmony for color | Design/accessibility rules across all tokens | Minimal | Extend validators per type; quality scoring |
+| Generation/Exports | Generators in code (CSS/React/Tailwind/W3C) not surfaced in UI | Full export suite + diffing | Some style guide generation | Add export UI; token diffing; Figma export hook |
+| Persistence | Projects table; colors stored; spacing tokens in JSON; project image stored | Token library, versioned snapshots, rollback | Projects + colors | Add spacing/typography tables; snapshot table; rollback/versioning |
+| Sessions/Runs | Not exposed; manual project ID | Session dashboard, run history, ownership | Simple runs | Build session service; per-run telemetry; ownership enforcement |
+| Auth/Gov | owner_id column only | AuthN/Z, ACL, audit, rate limits | None | Implement auth; tenant scoping; quotas |
+| Observability | /metrics only | Per-run metrics/logs dashboards | Minimal | Instrument pipeline; store run metrics; UI dashboard |
+| UI | Advanced color/spacing page; Save disabled until tokens; load restores image/spacing metadata | Unified Copy That home; demos for all tokens | Simple color demo | Make `/` the unified page; add typography/shadow demos; SSE-driven updates |
+| Failover | CV fallback if AI fails | Graceful 0-many tokens; retries | Some fallbacks | Add retries/backoff per type; snapshot commit even on partials |
+
+---
+
+## Architectural Alignment (Guidance)
+- **CV-first, AI-second (streaming):** Already for color/spacing; extend to all token types; emit CV tokens immediately, then AI deltas via SSE tagged by token type/id.
+- **Canonical token schema + adapters:** Keep one token model with per-type extensions; avoid duplicate fields; provenance shows source (cv/ai/user) and step.
+- **Snapshot-first persistence:** Projects own immutable snapshots (all token types + source image + preprocess manifest). Store per-type tables for query; snapshot blob for restore.
+- **Registry-driven extractors/generators:** Register CV extractor + AI refiner + generator per token type; orchestrator fans out based on requested token types.
+- **Fail-safe:** Allow 0-many tokens; CV fallback; partial commits; retries around AI calls.
+
+---
+
+## Recommended Next Moves (ordered)
+1) **Routing/UI:** Make `/` the unified Copy That page; keep `/color` and `/spacing` as focused demos.
+2) **Token coverage:** Port archive CV extractors for typography/shadow; add spacing DB table + `/projects/{id}/spacing`; add snapshot entity.
+3) **Multi-token extract endpoint:** Accept token_types list; run CV in parallel; stream AI refinements; merge per token id.
+4) **Snapshots & persistence:** Add project_snapshots with versioning; move spacing out of description JSON; store source image ref.
+5) **Export surface:** Expose generators (CSS/React/Tailwind/W3C/Figma) in UI with diffing.
+6) **Validation:** Extend validators per type (spacing, typography, shadow) with scoring.
+7) **Observability:** Per-run metrics/logs; UI dashboard; keep graceful partial success.
+8) **Auth/Governance:** Add authN/Z, ACL, audit, rate limits; enforce owner_id on projects/snapshots.
+
+---
+
+## Color Implementation Plan (Copy That vs Copy-This-Archive)
+**Current (copy-that):** CV+AI (OpenAI) with SSE; rich metadata (WCAG, semantic names, harmony); colors persisted per project; UI saves/loads projects; spacing tokens also fetched on load. Missing batch/multi-image, snapshots/versioning, exports UI, provenance graph, diffing, token-level retry, observability, auth.
+
+**Archive strengths to reuse:** richer CV palette/histogram analysis (coloraide), tiered AI prompts, variation system, style guide generator, schema validator, batch extract/routing planner.
+
+**Plan (phased):**
+1) Extractors: port archive CV color extractor (palette + histogram significance); add tiered AI modes; keep OpenAI default; add batch color endpoint.
+2) Persistence: add `project_snapshots` (immutable bundles of all colors + source image); versioning/rollback; provenance per token (source cv/ai/user, model, step).
+3) Variation/Style guide: port variation system and style guide generator; expose `/exports/style-guide`; UI panel.
+4) Exports/Diff: surface generators (CSS/React/Tailwind/W3C/Figma stub); snapshot diff API + UI.
+5) Quality/Retry: add quality scores; token-level retry/backoff for AI; CV fallback always.
+6) Observability/Auth: per-run metrics/logs; dashboards; enforce ownership/rate limits on color endpoints.
+7) UI: wire SSE multi-extract to show color streaming, batch runs, exports/diff, snapshot restore.
+
+Recent changes:
+- Added batch color endpoint (`/api/v1/colors/batch`) with optional persistence.
+- Added project_snapshots table and snapshot persistence for color+spacing via SSE multi-extract.
+
+---
+
+## Spacing Implementation Plan (Copy That vs Copy-This-Archive)
+**Current (copy-that):** CV spacing (OpenCV gaps) + AI refinement (OpenAI); SSE streaming; DB table `spacing_tokens`; project load fetches spacing tokens; saved image retained. Missing typography/shadow, snapshots/versioning, variation system for spacing, exports UI, batch/multi-image, provenance, diffing, observability, auth.
+
+**Archive strengths to reuse:** richer spacing extractors (edge + SAM, enhanced spacing), variation system (compact/standard/spacious), validation rules, style guide outputs, batch extraction, routing planner.
+
+**Plan (phased):**
+1) Extractors: port archive enhanced spacing (SAM/edge) as CV fast path; keep OpenAI refinement; add batch spacing endpoint.
+2) Persistence: include spacing in `project_snapshots` with versioning/rollback; keep `spacing_tokens` table; provenance fields.
+3) Variation/Style guide: port spacing variation system and style guide pieces; expose in exports API/UI.
+4) Exports/Diff: include spacing in CSS/Tailwind/W3C exports; snapshot diff API/UI.
+5) Quality/Retry: spacing validation (grid compliance, density), quality scores, retry/backoff for AI, CV fallback.
+6) Observability/Auth: per-run metrics/logs; dashboards; enforce ownership/rate limits.
+7) UI: SSE multi-extract shows spacing streaming; load snapshot restores spacing; batch UI for multi-image spacing.

--- a/docs/architecture/color_spacing_parity.md
+++ b/docs/architecture/color_spacing_parity.md
@@ -1,0 +1,69 @@
+Here’s a comprehensive evaluation of color implementation, comparing what we have in copy-that vs. what’s available in copy-this-archive, plus a concrete plan to close the gaps.
+
+Current State – copy-that
+
+- Extractors: CV-first (Pillow+coloraide) + AI (OpenAI) with SSE streaming; merges CV+AI; robust metadata (WCAG, semantic names, harmony, temperature, variants).
+- Persistence: Colors persisted to DB per project; project save/load works; SSE path streams color tokens.
+- UI: Unified page at / with upload, parallel extract (color+spacing), project save/load; shows tokens (no typography/shadow panels yet).
+- Gaps: No batch/multi-image; no token provenance graph; exports not surfaced (CSS/React/Tailwind/W3C, Figma); no diffing; no per-token retry/backoff; no color snapshot versioning; no streaming UI for additional token types.
+
+What copy-this-archive offers (color)
+
+- Rich CV extractors: coloraide quantization, palette analysis, histogram significance.
+- AI refiners (Claude/OpenAI), prompt-rich, tiered models.
+- Variation system (compact/standard/spacious), style guide generator.
+- Schema validator, routing planner, batch extraction.
+- Style guide outputs and Tailwind/React/W3C hooks (scattered).
+
+Gaps there: loose typing, duplication, limited governance/observability.
+
+What’s missing in copy-that vs archive
+- Batch/multi-image color extraction and aggregation.
+- Variation system and style guide generation exposed in API/UI.
+- Export/diff surface (CSS/React/Tailwind/W3C/Figma).
+- Provenance/lineage and token-level quality scoring.
+- Snapshot/versioning for colors (per-project immutable snapshots).
+- Observability: per-run timings/metrics/logs for color pipeline.
+- Auth/governance: none enforced in UI/API.
+
+Implementation Plan (color)
+Extractors
+- Port archive’s richer CV color extractor (palette, histogram significance) into copy_that.application.cv.
+- Add tiered AI models (fast/rich) and configurable prompts; keep OpenAI as default.
+- Add batch endpoint: multi-image color extraction + aggregation.
+
+Persistence/Snapshots
+- Add project_snapshots table with immutable blobs (all color tokens + source image + metadata) and versioning/rollback.
+- Keep per-token tables for querying; link tokens to snapshots.
+
+Variation/Style Guide
+- Port variation system (compact/standard/spacious) and style guide generator; expose via /exports/style-guide and UI panel.
+
+Exports & Diffing
+- Surface generators (CSS/React/Tailwind/W3C, Figma stub) via API + UI.
+- Add snapshot diff endpoint (old vs new) and UI view.
+
+Provenance/Quality
+- Add provenance fields (source cv/ai/user, model, step) per token.
+- Add quality scoring (contrast, harmony, semantic name confidence).
+- Token-level retry/backoff around AI; keep CV fallback.
+
+Streaming/UI
+- Extend SSE to batch and multi-token types; keep CV-first, AI-second updates per token id.
+- Show streaming state per token type; allow cancel/retry.
+
+Observability
+- Instrument per-run metrics (latency CV/AI, token counts, errors); store logs; dashboard view.
+
+Auth/Governance
+Enforce project ownership on color endpoints; add authN/Z, rate limits; audit logs.
+
+Not yet surfaced in the UI or API contracts you use day‑to‑day:
+
+Token types: Typography/shadow/radius/animation aren’t exposed; SSE still streams only color + spacing.
+Batch endpoints: Color batch and spacing batch exist, but the UI doesn’t call them.
+Snapshots: List/fetch endpoints are live and “Load Latest Snapshot” is wired, but there’s no snapshot list/selector in the UI or restore of other types.
+Enhanced CV extractors: Only basic CV color/spacing are live; enriched palette/histogram (color) and SAM/edge spacing are not ported/exposed yet.
+Exports/Variation: Generators (CSS/React/Tailwind/W3C/Figma), variation/style-guide, and diffing are not exposed in the UI.
+Provenance/quality/observability: Provenance graph, quality scores, per-run metrics/logs, and dashboards aren’t exposed.
+Auth/governance: No UI or API enforcement of auth/ownership/rate limits.yes

--- a/docs/planning/sessions/session-0-6-cleanup.md
+++ b/docs/planning/sessions/session-0-6-cleanup.md
@@ -5,6 +5,9 @@
 - QualityScorer reports include `palette_harmony_score` and improved recommendations; tests expanded accordingly.
 - GeneratorAgent gains Figma export (`figma.j2`) and token diff utilities (`generator/diff.py`) plus coverage for the new format.
 - General lint/format fixes and ruff version alignment to keep CI green.
+- Added CLI helper for Figma export (`scripts/generate_figma_tokens.py`) and associated tests.
+- Color HTML demo enriched with filtering (WCAG/harmony), semantic metadata, and richer token detail rendering.
+- Spacing token suite merged from main; planning/reference code reviewed for reuse.
 
 ## Orchestrator Integration
 - Coordinator continues to wire Preprocess → Extract → Aggregate → Validate → Generate using agents from Sessions 1-5; color pipeline e2e tests pass after validation/generation enhancements.
@@ -17,11 +20,12 @@
 5. Performance tweaks via precompiled regexes and lightweight checks.
 
 ## Session 5 “Next Steps” Progress
-- Added Figma export format to generator templates.
+- Added Figma export format to generator templates + CLI helper + tests.
 - Added token diff utility for comparing generations.
-- HTML demo unchanged (no interactive revamp yet).
-- Figma export in place; token diffing delivered; ValidationAgent integration improved. Outstanding: richer interactive demo, Figma-specific tests/CLI wiring if needed.
+- Color HTML demo now more interactive; spacing demo already rich (filters/education still planned).
+- Outstanding: deeper React demos parity, Figma wiring into CLI entrypoints, and doc polish.
 
 ## Notes
 - Spacing token work was merged into main before the latest rebase; branch rebased onto main successfully.
 - All validation/generator unit suites pass; pre-commit hooks (ruff/mypy/pytest-fast) currently green.
+- Reviewed `docs/planning/token-pipeline-planning` vs `reference-implementation`: spacing models/aggregators/routers match current code; remaining reusable pieces (spacing utils, CV hooks, batch extractor) available to tap in Session 7 plan; production readiness checklist captured for next steps.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -5,8 +5,10 @@
 .app {
   display: flex;
   flex-direction: column;
-  height: 100%;
+  min-height: 100vh;
+  height: auto;
   background: var(--color-bg);
+  overflow-y: auto;
 }
 
 /* ========================================
@@ -73,9 +75,12 @@
 
 .app-layout {
   display: flex;
-  flex: 1;
-  overflow: hidden;
+  flex: 1 0 auto;
+  overflow: visible;
+  overflow-y: auto;
   width: 100%;
+  align-items: flex-start;
+  min-height: 0;
 }
 
 /* ========================================
@@ -83,19 +88,35 @@
    ======================================== */
 
 .app-main {
-  flex: 1;
+  flex: 1 0 auto;
   display: flex;
   flex-direction: column;
   width: 100%;
-  overflow: hidden;
+  overflow: visible;
+  padding: var(--space-lg);
   background: var(--color-bg);
+  gap: var(--space-lg);
 }
 
-/* Ensure child components fill space */
-.app-main > * {
-  width: 100%;
-  height: 100%;
-  flex: 1;
+/* Layout overrides to keep token grid visible without excessive height */
+.color-tokens.layout-new {
+  height: auto !important;
+  background: transparent !important;
+}
+
+.palette-container,
+.detail-container {
+  overflow: visible !important;
+}
+
+.palette-selector {
+  height: auto !important;
+  max-height: 520px;
+}
+
+.token-grid {
+  flex: unset !important;
+  overflow: visible !important;
 }
 
 /* ========================================

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,109 +1,20 @@
-import { useState } from 'react'
-import ImageUploader from './components/ImageUploader'
-import TokenToolbar from './components/TokenToolbar'
-import TokenGrid from './components/TokenGrid'
-import TokenInspectorSidebar from './components/TokenInspectorSidebar'
-import TokenPlaygroundDrawer from './components/TokenPlaygroundDrawer'
-import { useTokenStore } from './store/tokenStore'
-import { ColorToken } from './types'
+import { useEffect, useState } from 'react'
 import './App.css'
+import AdvancedColorScienceDemo from './components/AdvancedColorScienceDemo'
+import SpacingTokenShowcase from './components/SpacingTokenShowcase'
 
 export default function App() {
-  const [projectId, setProjectId] = useState<string | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [loading, setLoading] = useState(false)
+  // Ensure global scroll isn’t disabled by other styles
+  useEffect(() => {
+    const originalBodyOverflow = document.body.style.overflowY
+    const originalHtmlOverflow = document.documentElement.style.overflowY
+    document.body.style.overflowY = 'auto'
+    document.documentElement.style.overflowY = 'auto'
+    return () => {
+      document.body.style.overflowY = originalBodyOverflow
+      document.documentElement.style.overflowY = originalHtmlOverflow
+    }
+  }, [])
 
-  // Store hooks
-  const { setTokens, setProjectId: setStoreProjectId, tokens, isExtracting } = useTokenStore()
-
-  // Create or manage project
-  const handleProjectCreated = (id: number) => {
-    const projectIdStr = String(id)
-    setProjectId(projectIdStr)
-    setStoreProjectId(projectIdStr)
-    setError(null)
-  }
-
-  // Handle color extraction
-  const handleColorExtracted = (extractedColors: ColorToken[]) => {
-    setTokens(extractedColors)
-    setLoading(false)
-    setError(null)
-  }
-
-  const handleError = (errorMsg: string) => {
-    setError(errorMsg)
-    setLoading(false)
-  }
-
-  const handleLoadingChange = (isLoading: boolean) => {
-    setLoading(isLoading)
-  }
-
-  return (
-    <div className="app">
-      {/* Header */}
-      <header className="app-header">
-        <div className="header-content">
-          <div className="header-title">
-            <h1>Copy That</h1>
-            {projectId != null && projectId !== '' && <span className="project-id">Project: {projectId}</span>}
-          </div>
-          <div className="header-upload">
-            <ImageUploader
-              projectId={projectId != null && projectId !== '' ? parseInt(projectId) : null}
-              onProjectCreated={handleProjectCreated}
-              onColorExtracted={handleColorExtracted}
-              onError={handleError}
-              onLoadingChange={handleLoadingChange}
-            />
-          </div>
-        </div>
-        {error != null && error !== '' && (
-          <div className="error-banner">
-            <span>⚠️ {error}</span>
-          </div>
-        )}
-      </header>
-
-      {/* Main Layout */}
-      <div className="app-layout">
-        {/* Playground Drawer (Left) */}
-        <TokenPlaygroundDrawer />
-
-        {/* Main Content Area */}
-        <main className="app-main">
-          {/* Loading State */}
-          {(loading || isExtracting) && (
-            <div className="loading-state">
-              <div className="spinner"></div>
-              <p>Extracting colors...</p>
-            </div>
-          )}
-
-          {/* Token Grid View */}
-          {!loading && !isExtracting && tokens.length > 0 && (
-            <>
-              <TokenToolbar />
-              <TokenGrid />
-            </>
-          )}
-
-          {/* Empty State */}
-          {!loading && !isExtracting && tokens.length === 0 && (error == null || error === '') && (
-            <div className="empty-state">
-              <div className="empty-content">
-                <p className="empty-icon">🎨</p>
-                <p className="empty-title">Upload an image to begin</p>
-                <p className="empty-subtitle">Extract colors and explore their properties</p>
-              </div>
-            </div>
-          )}
-        </main>
-
-        {/* Inspector Sidebar (Right) */}
-        <TokenInspectorSidebar />
-      </div>
-    </div>
-  )
+  return <AdvancedColorScienceDemo />
 }

--- a/frontend/src/api/schemas.ts
+++ b/frontend/src/api/schemas.ts
@@ -29,7 +29,7 @@ export const ColorTokenSchema = z.object({
 
   // Design token properties
   design_intent: z.string().optional(),
-  semantic_names: z.union([z.string(), z.record(z.string())]).optional(),
+  semantic_names: z.union([z.string(), z.record(z.unknown())]).optional(),
   category: z.string().optional(),
 
   // Color analysis properties (required confidence with range validation)

--- a/frontend/src/components/AdvancedColorScienceDemo.css
+++ b/frontend/src/components/AdvancedColorScienceDemo.css
@@ -1,32 +1,31 @@
 .advanced-color-science-demo {
-  --primary: #667eea;
-  --primary-dark: #5a6fd6;
-  --secondary: #764ba2;
-  --text: #333;
-  --text-light: #666;
-  --text-muted: #999;
-  --bg: #f8f9ff;
-  --card-bg: white;
-  --border: #e0e0e0;
+  --primary: #4f46e5;
+  --primary-dark: #4338ca;
+  --secondary: #7c3aed;
+  --text: #1f2933;
+  --text-light: #4b5563;
+  --text-muted: #6b7280;
+  --bg: #f6f7fb;
+  --card-bg: #ffffff;
+  --border: #e5e7eb;
   --success: #10b981;
   --warning: #f59e0b;
   --error: #ef4444;
 
   min-height: 100vh;
-  background: linear-gradient(135deg, var(--primary) 0%, var(--secondary) 100%);
+  background: #f6f7fb;
   padding: 20px;
 }
 
 .demo-header {
   text-align: center;
-  color: white;
+  color: var(--text);
   margin-bottom: 20px;
 }
 
 .demo-header h1 {
   font-size: 2rem;
   margin: 0 0 8px 0;
-  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
 }
 
 .demo-header p {
@@ -36,17 +35,19 @@
 
 .demo-layout {
   display: grid;
-  grid-template-columns: 320px 1fr 360px;
+  grid-template-columns: 340px 1fr 380px;
   gap: 20px;
-  max-width: 1600px;
+  max-width: 1640px;
   margin: 0 auto;
+  align-items: start;
 }
 
 .panel-card {
   background: var(--card-bg);
   border-radius: 12px;
   padding: 16px;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+  border: 1px solid var(--border);
 }
 
 .panel-card h2 {
@@ -93,6 +94,64 @@
   color: var(--text-light);
   margin: 0;
   font-size: 0.9rem;
+}
+
+.project-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.field input {
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.project-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.small-btn {
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  background: #fff;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.small-btn:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.load-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.load-input {
+  width: 120px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.project-meta {
+  font-size: 0.85rem;
+  color: var(--text-light);
 }
 
 .preview-image {
@@ -364,9 +423,8 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
   gap: 12px;
-  max-height: 500px;
-  overflow-y: auto;
-  padding-right: 8px;
+  overflow: visible;
+  padding-right: 0;
 }
 
 .color-card {
@@ -427,6 +485,7 @@
 .tag.harmony { background: #fef3c7; color: #92400e; }
 .tag.temp { background: #fee2e2; color: #991b1b; }
 .tag.wcag-pass { background: #d1fae5; color: #065f46; }
+.tag.confidence { background: #eef2ff; color: var(--primary); font-weight: 700; }
 
 .confidence-bar {
   height: 3px;

--- a/frontend/src/components/ColorDetailPanel.css
+++ b/frontend/src/components/ColorDetailPanel.css
@@ -1,12 +1,12 @@
 .detail-panel {
   display: flex;
   flex-direction: column;
-  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  background: #fff;
   border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--color-neutral-200);
   height: 100%;
   overflow: hidden;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
 }
 
 .detail-panel.empty {
@@ -16,7 +16,7 @@
 
 .empty-state {
   text-align: center;
-  color: #888;
+  color: var(--color-text-secondary);
   padding: 3rem 2rem;
 }
 
@@ -29,20 +29,20 @@
 .empty-state h3 {
   margin: 0.5rem 0;
   font-size: 1.25rem;
-  color: #b0b0b0;
+  color: var(--color-text-primary);
 }
 
 .empty-state p {
   margin: 0.5rem 0 0 0;
   font-size: 0.9rem;
-  color: #888;
+  color: var(--color-text-secondary);
 }
 
 /* Header */
 .detail-header {
   padding: 1.5rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-  background: rgba(0, 0, 0, 0.2);
+  border-bottom: 1px solid var(--color-neutral-200);
+  background: #f8f8f8;
 }
 
 .header-top {
@@ -78,7 +78,7 @@
   margin: 0;
   font-size: 1.5rem;
   font-weight: 600;
-  color: #fff;
+  color: var(--color-text-primary);
   word-break: break-word;
 }
 
@@ -107,7 +107,7 @@
 
 .confidence-badge {
   font-size: 0.85rem;
-  color: #aaa;
+  color: var(--color-text-secondary);
   display: block;
   margin-top: 0.25rem;
 }
@@ -115,9 +115,10 @@
 .count-info {
   text-align: center;
   padding: 0.75rem 1rem;
-  background: rgba(79, 70, 229, 0.1);
+  background: var(--color-accent-light);
   border-radius: 6px;
   border-left: 3px solid #4f46e5;
+  color: var(--color-text-secondary);
 }
 
 .count-value {
@@ -130,7 +131,7 @@
 .count-label {
   display: block;
   font-size: 0.75rem;
-  color: #888;
+  color: var(--color-text-secondary);
   text-transform: uppercase;
   margin-top: 0.25rem;
 }
@@ -259,7 +260,7 @@
 .overview-content {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 0.9rem;
 }
 
 .overview-section h3,
@@ -275,7 +276,7 @@
 .info-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 0.75rem;
+  gap: 0.5rem;
 }
 
 .info-item,

--- a/frontend/src/components/ColorDetailPanel.tsx
+++ b/frontend/src/components/ColorDetailPanel.tsx
@@ -4,6 +4,7 @@ import { AccessibilityVisualizer } from './AccessibilityVisualizer'
 import { useState } from 'react'
 import { ColorToken } from '../types'
 import { copyToClipboard } from '../utils'
+import { formatSemanticValue } from '../utils/semanticNames'
 
 interface Props {
   color: ColorToken | null
@@ -172,19 +173,31 @@ function OverviewTab({ color }: { color: ColorToken }) {
         </div>
       </section>
 
-      {color.semantic_names != null && Object.keys(color.semantic_names).length > 0 && (
-        <section className="overview-section">
-          <h3>Semantic Names</h3>
-          <div className="semantic-grid">
-            {Object.entries(color.semantic_names).map(([key, value]) => (
-              <div key={key} className="semantic-item">
-                <span className="semantic-key">{key}</span>
-                <span className="semantic-value">{value}</span>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
+      {(() => {
+        const entries =
+          typeof color.semantic_names === 'string'
+            ? [['label', color.semantic_names] as const]
+            : color.semantic_names
+              ? Object.entries(color.semantic_names)
+              : []
+
+        return entries.length > 0 ? (
+          <section className="overview-section">
+            <h3>Semantic Names</h3>
+            <div className="semantic-grid">
+              {entries.map(([key, value]) => {
+                const formatted = formatSemanticValue(value)
+                return (
+                  <div key={key} className="semantic-item">
+                    <span className="semantic-key">{key}</span>
+                    <span className="semantic-value">{formatted}</span>
+                  </div>
+                )
+              })}
+            </div>
+          </section>
+        ) : null
+      })()}
 
       {color.prominence_percentage != null && (
         <section className="overview-section">
@@ -198,6 +211,37 @@ function OverviewTab({ color }: { color: ColorToken }) {
           <span className="prominence-value">
             {color.prominence_percentage?.toFixed(1)}% of image
           </span>
+        </section>
+      )}
+      {color.extraction_metadata && (
+        <section className="overview-section">
+          <h3>Source & Model</h3>
+          <div className="info-grid">
+            {color.extraction_metadata.model && (
+              <div className="info-item">
+                <label>Model</label>
+                <span>{String(color.extraction_metadata.model)}</span>
+              </div>
+            )}
+            {color.extraction_metadata.extractor && (
+              <div className="info-item">
+                <label>Extractor</label>
+                <span>{String(color.extraction_metadata.extractor)}</span>
+              </div>
+            )}
+            {color.extraction_metadata.source && (
+              <div className="info-item">
+                <label>Source</label>
+                <span>{String(color.extraction_metadata.source)}</span>
+              </div>
+            )}
+            {color.histogram_significance != null && (
+              <div className="info-item">
+                <label>Histogram Significance</label>
+                <span>{(color.histogram_significance * 100).toFixed(2)}%</span>
+              </div>
+            )}
+          </div>
         </section>
       )}
     </div>

--- a/frontend/src/components/ColorDetailsPanel.tsx
+++ b/frontend/src/components/ColorDetailsPanel.tsx
@@ -1,10 +1,11 @@
 import './ColorDetailsPanel.css'
+import { formatSemanticValue } from '../utils/semanticNames'
 
 interface ColorToken {
   hex: string
   name: string
   confidence: number
-  semantic_names?: Record<string, string> | null
+  semantic_names?: Record<string, unknown> | null
   temperature?: string
   saturation_level?: string
   lightness_level?: string
@@ -53,19 +54,31 @@ export function ColorDetailsPanel({ color }: Props) {
       </div>
 
       {/* Semantic Names */}
-      {color.semantic_names != null && Object.keys(color.semantic_names).length > 0 && (
-        <div className="section">
-          <h4>Semantic Names</h4>
-          <ul className="semantic-list">
-            {Object.entries(color.semantic_names).map(([style, name]) => (
-              <li key={style}>
-                <span className="style-label">{style}</span>
-                <span className="style-value">{name}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+      {(() => {
+        const entries =
+          typeof color.semantic_names === 'string'
+            ? [['label', color.semantic_names] as const]
+            : color.semantic_names
+              ? Object.entries(color.semantic_names)
+              : []
+
+        return entries.length > 0 ? (
+          <div className="section">
+            <h4>Semantic Names</h4>
+            <ul className="semantic-list">
+              {entries.map(([style, name]) => {
+                const formatted = formatSemanticValue(name)
+                return (
+                  <li key={style}>
+                    <span className="style-label">{style}</span>
+                    <span className="style-value">{formatted}</span>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        ) : null
+      })()}
 
       {/* WCAG Accessibility */}
       <div className="section">

--- a/frontend/src/components/ColorNarrative.tsx
+++ b/frontend/src/components/ColorNarrative.tsx
@@ -4,7 +4,7 @@ import './ColorNarrative.css'
 interface ColorNarrativeProps {
   hex: string
   name: string
-  semanticNames?: Record<string, string> | null
+  semanticNames?: Record<string, unknown> | null
   temperature?: string
   saturationLevel?: string
   lightnessLevel?: string

--- a/frontend/src/components/ColorPaletteSelector.css
+++ b/frontend/src/components/ColorPaletteSelector.css
@@ -1,17 +1,17 @@
 .palette-selector {
   padding: 1.5rem;
-  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  background: #fff;
   border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  height: 100%;
-  overflow-y: auto;
+  border: 1px solid var(--color-neutral-200);
+  height: auto;
+  overflow-y: visible;
 }
 
 .palette-title {
   margin: 0 0 1rem 0;
   font-size: 1rem;
-  font-weight: 600;
-  color: #e0e0e0;
+  font-weight: 700;
+  color: var(--color-text-primary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -30,19 +30,19 @@
   padding: 0.5rem;
   border-radius: 8px;
   transition: all 0.2s ease;
-  border: 2px solid transparent;
-  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--color-neutral-200);
+  background: var(--color-bg-secondary);
 }
 
 .palette-swatch:hover {
-  background: rgba(255, 255, 255, 0.1);
+  background: #f7f7f7;
   transform: translateY(-2px);
 }
 
 .palette-swatch.selected {
-  border-color: #4f46e5;
-  background: rgba(79, 70, 229, 0.2);
-  box-shadow: 0 0 12px rgba(79, 70, 229, 0.3);
+  border-color: var(--color-neutral-300);
+  background: #f5f5f5;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.05);
 }
 
 .swatch-color {
@@ -76,7 +76,7 @@
 
 .swatch-hex {
   font-size: 0.75rem;
-  color: #a0a0a0;
+  color: var(--color-text-primary);
   font-family: 'Monaco', 'Courier New', monospace;
   display: block;
   text-align: center;
@@ -84,19 +84,19 @@
 }
 
 .palette-swatch:hover .swatch-hex {
-  color: #e0e0e0;
+  color: var(--color-text-primary);
 }
 
 .swatch-confidence {
   font-size: 0.7rem;
-  color: #888;
+  color: var(--color-text-secondary);
   text-align: center;
   display: block;
 }
 
 .palette-swatch.selected .swatch-hex,
 .palette-swatch.selected .swatch-confidence {
-  color: #4f46e5;
+  color: var(--color-text-primary);
 }
 
 /* Scrollbar styling */

--- a/frontend/src/components/ColorPrimaryPreview.css
+++ b/frontend/src/components/ColorPrimaryPreview.css
@@ -1,0 +1,36 @@
+.color-primary-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid var(--color-neutral-200);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+.color-primary-swatch {
+  width: 100%;
+  height: 120px;
+  border-radius: 10px;
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.06);
+}
+
+.color-primary-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.color-primary-name {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.color-primary-hex {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+  font-family: 'Monaco', 'Courier New', monospace;
+}

--- a/frontend/src/components/ColorPrimaryPreview.tsx
+++ b/frontend/src/components/ColorPrimaryPreview.tsx
@@ -1,0 +1,27 @@
+import { ColorToken } from '../types'
+import './ColorPrimaryPreview.css'
+
+interface Props {
+  token: Partial<ColorToken>
+}
+
+/**
+ * Minimal primary preview for color tokens.
+ * Shows a single swatch with a subtle glow and optional accent chip.
+ */
+export function ColorPrimaryPreview({ token }: Props) {
+  const hex = token.hex ?? '#cccccc'
+  const name = token.name ?? 'Color'
+
+  return (
+    <div className="color-primary-preview">
+      <div className="color-primary-swatch" style={{ backgroundColor: hex }}>
+        <div className="color-primary-glow" />
+      </div>
+      <div className="color-primary-meta">
+        <span className="color-primary-name">{name}</span>
+        <code className="color-primary-hex">{hex}</code>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ColorTokenDisplay.css
+++ b/frontend/src/components/ColorTokenDisplay.css
@@ -1,23 +1,29 @@
 /* New side-by-side layout */
 .color-tokens.layout-new {
-  display: grid;
-  grid-template-columns: 280px 1fr;
-  gap: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   width: 100%;
-  height: calc(100vh - 80px);
+  height: auto;
   padding: 0;
-  background: #0f0f1e;
+  background: var(--color-bg-secondary);
 }
 
 .palette-container {
-  overflow-y: auto;
-  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
-  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  overflow: visible;
+  background: var(--color-bg);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: 12px;
+  padding: 1rem;
 }
 
 .detail-container {
-  overflow-y: auto;
-  padding-right: 1rem;
+  overflow: visible;
+  padding-right: 0;
+  background: var(--color-bg);
+  border: 1px solid var(--color-neutral-200);
+  border-radius: 12px;
+  padding: 1rem;
 }
 
 /* Scrollbar styling */
@@ -45,14 +51,11 @@
 /* Mobile layout */
 @media (max-width: 1024px) {
   .color-tokens.layout-new {
-    grid-template-columns: 1fr;
     height: auto;
   }
 
   .palette-container {
-    border-right: none;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-    max-height: 300px;
+    border-bottom: none;
   }
 }
 

--- a/frontend/src/components/CompactColorGrid.tsx
+++ b/frontend/src/components/CompactColorGrid.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 import './CompactColorGrid.css'
+import { pickPreferredSemanticName } from '../utils/semanticNames'
 
 interface ColorToken {
   id?: number
   hex: string
   rgb?: string
   name: string
-  semantic_names?: Record<string, string> | null
+  semantic_names?: Record<string, unknown> | null
   confidence: number
   temperature?: string
   saturation_level?: string
@@ -29,12 +30,8 @@ export function CompactColorGrid({ colors = [], selectedId, onSelectColor }: Pro
   const [copiedHex, setCopiedHex] = useState<string | null>(null)
 
   const getColorDisplayName = (color: ColorToken) => {
-    // Use descriptive name from semantic_names if available
-    if (color.semantic_names?.descriptive != null && color.semantic_names.descriptive !== '') {
-      return color.semantic_names.descriptive
-    }
-    // Otherwise use the color name
-    return color.name
+    const semantic = pickPreferredSemanticName(color.semantic_names)
+    return semantic ?? color.name
   }
 
   const handleCopy = (hex: string, e: React.MouseEvent) => {

--- a/frontend/src/components/EducationalColorDisplay.tsx
+++ b/frontend/src/components/EducationalColorDisplay.tsx
@@ -10,7 +10,7 @@ interface ColorToken {
   rgb?: string
   hsl?: string
   name: string
-  semantic_names?: Record<string, string> | null
+  semantic_names?: Record<string, unknown> | null
   confidence: number
   temperature?: string
   saturation_level?: string

--- a/frontend/src/components/HarmonyVisualizer.css
+++ b/frontend/src/components/HarmonyVisualizer.css
@@ -1,9 +1,11 @@
 .harmony-visualizer {
-  background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+  background: #fff;
   border-radius: 12px;
-  padding: 24px;
-  margin: 20px 0;
-  border-left: 4px solid #667eea;
+  padding: 16px;
+  margin: 12px 0;
+  border: 1px solid var(--color-neutral-200);
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .harmony-header {
@@ -24,8 +26,9 @@
 
 .harmony-content {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 30px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  width: 100%;
 }
 
 .harmony-wheel-section {
@@ -43,9 +46,9 @@
 }
 
 .wheel-container {
-  width: 200px;
-  height: 200px;
-  margin: 20px 0;
+  width: 180px;
+  height: 180px;
+  margin: 12px 0;
 }
 
 .hue-wheel {

--- a/frontend/src/components/ImageUploader.tsx
+++ b/frontend/src/components/ImageUploader.tsx
@@ -165,7 +165,10 @@ export default function ImageUploader({
         for (const line of lines) {
           if (line.startsWith('data: ')) {
             try {
-              const event = JSON.parse(line.slice(6)) as StreamEvent
+              // Some upstream sources may emit non-JSON tokens like NaN; sanitize before parsing
+              const rawPayload = line.slice(6)
+              const sanitizedPayload = rawPayload.replace(/\bNaN\b/g, 'null')
+              const event = JSON.parse(sanitizedPayload) as StreamEvent
               console.log('Stream event:', event)
 
               if (event.error != null) {
@@ -290,7 +293,7 @@ export default function ImageUploader({
         disabled={!selectedFile}
         title={selectedFile != null ? 'Ready to extract colors' : 'Please select an image first'}
       >
-        ✨ Extract Colors {selectedFile ? `(${selectedFile.name})` : ''}
+        ✨ Extract Colors
       </button>
 
       {/* Project Info */}

--- a/frontend/src/components/PlaygroundSidebar.tsx
+++ b/frontend/src/components/PlaygroundSidebar.tsx
@@ -4,7 +4,7 @@ import './PlaygroundSidebar.css'
 interface ColorToken {
   hex: string
   name: string
-  semantic_names?: Record<string, string> | null
+  semantic_names?: Record<string, unknown> | null
   tint_color?: string
   shade_color?: string
   tone_color?: string

--- a/frontend/src/components/TokenCard.css
+++ b/frontend/src/components/TokenCard.css
@@ -5,13 +5,14 @@
 .token-card {
   display: flex;
   flex-direction: column;
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
-  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 12px;
+  background: #fafafa;
   cursor: pointer;
   transition: all 0.2s ease;
   padding: 0;
   overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
 }
 
 .token-card:hover {
@@ -41,9 +42,9 @@
 .token-card__swatch {
   width: 48px;
   height: 48px;
-  border-radius: 6px;
-  border: 1px solid #ccc;
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  border: 1px solid #d5d5d5;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
 }
 
 .token-card__metadata {
@@ -132,7 +133,7 @@
 /* Primary Visual */
 .token-card__primary {
   padding: 12px;
-  background: #fafafa;
+  background: #fff;
 }
 
 /* Details (Expanded) */

--- a/frontend/src/components/TokenGrid.css
+++ b/frontend/src/components/TokenGrid.css
@@ -7,7 +7,7 @@
   gap: 16px;
   padding: 16px;
   flex: 1;
-  overflow-y: auto;
+  overflow: visible;
 }
 
 .token-grid--grid {

--- a/frontend/src/config/tokenTypeRegistry.tsx
+++ b/frontend/src/config/tokenTypeRegistry.tsx
@@ -12,7 +12,7 @@ import { FC, ComponentType } from 'react';
 import { ColorToken } from '../types';
 
 // Import existing color components
-import ColorTokenDisplay from '../components/ColorTokenDisplay';
+import { ColorPrimaryPreview } from '../components/ColorPrimaryPreview';
 import { HarmonyVisualizer } from '../components/HarmonyVisualizer';
 import { AccessibilityVisualizer } from '../components/AccessibilityVisualizer';
 import { ColorNarrative } from '../components/ColorNarrative';
@@ -125,7 +125,7 @@ export const tokenTypeRegistry: Record<string, TokenTypeSchema> = {
   color: {
     name: 'Color',
     icon: ColorIcon,
-    primaryVisual: ColorTokenDisplay,
+    primaryVisual: ColorPrimaryPreview,
     formatTabs: [
       { name: 'RGB', component: ColorFormatTab_RGB },
       { name: 'HSL', component: ColorFormatTab_HSL },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -36,16 +36,18 @@ button:focus-visible {
   outline-offset: 2px;
 }
 
-/* Remove scrollbars for full-height layouts */
+/* Allow normal scrolling */
 html,
 body {
-  height: 100%;
-  overflow: hidden;
+  min-height: 100vh;
+  height: auto;
+  overflow-y: auto !important;
 }
 
 /* Root container */
 #root {
-  height: 100%;
+  min-height: 100vh;
+  height: auto;
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -27,7 +27,7 @@ export interface ColorToken {
 
   // Design token properties
   design_intent?: string;
-  semantic_names?: string | Record<string, string>;
+  semantic_names?: string | Record<string, unknown>;
   category?: string;
 
   // Color analysis properties

--- a/frontend/src/utils/semanticNames.ts
+++ b/frontend/src/utils/semanticNames.ts
@@ -1,0 +1,65 @@
+export function formatSemanticValue(value: unknown): string {
+  if (value == null) return ''
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  if (Array.isArray(value)) {
+    const flattened = value
+      .map((item) => formatSemanticValue(item))
+      .filter((item) => item !== '')
+    return flattened.join(', ')
+  }
+
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    const candidateKeys = ['name', 'label', 'title', 'value', 'display']
+
+    for (const key of candidateKeys) {
+      const candidate = record[key]
+      if (typeof candidate === 'string' && candidate.trim() !== '') {
+        return candidate
+      }
+    }
+
+    const nested = Object.values(record)
+      .map((item) => formatSemanticValue(item))
+      .filter((item) => item !== '')
+
+    if (nested.length > 0) {
+      return nested.join(', ')
+    }
+
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+
+  return String(value)
+}
+
+export function pickPreferredSemanticName(
+  semanticNames: Record<string, unknown> | string | null | undefined,
+  preferences: string[] = ['descriptive', 'simple', 'emotional', 'technical', 'vibrancy']
+): string | undefined {
+  if (!semanticNames) return undefined
+
+  if (typeof semanticNames === 'string') {
+    return semanticNames
+  }
+
+  for (const key of preferences) {
+    const value = semanticNames[key]
+    const formatted = formatSemanticValue(value)
+    if (formatted.trim() !== '') {
+      return formatted
+    }
+  }
+
+  const firstValue = Object.values(semanticNames)[0]
+  const formatted = formatSemanticValue(firstValue)
+  return formatted.trim() === '' ? undefined : formatted
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       zustand:
         specifier: ^5.0.8
-        version: 5.0.8(@types/react@18.3.27)(react@18.3.1)
+        version: 5.0.8(@types/react@18.3.27)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.1.5
@@ -57,6 +57,67 @@ importers:
       vitest:
         specifier: ^1.0.4
         version: 1.6.1(@vitest/ui@1.6.1)(jsdom@27.2.0)
+
+  frontend:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.0.0
+        version: 5.90.10(react@18.3.1)
+      axios:
+        specifier: ^1.6.0
+        version: 1.13.2
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+      zod:
+        specifier: ^3.22.0
+        version: 3.25.76
+      zustand:
+        specifier: ^4.4.0
+        version: 4.5.7(@types/react@18.3.27)(react@18.3.1)
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.1.0
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^14.0.0
+        version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/react':
+        specifier: ^18.2.0
+        version: 18.3.27
+      '@types/react-dom':
+        specifier: ^18.2.0
+        version: 18.3.7(@types/react@18.3.27)
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^6.0.0
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^6.0.0
+        version: 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@vitejs/plugin-react':
+        specifier: ^4.2.0
+        version: 4.7.0(vite@5.4.21)
+      eslint:
+        specifier: ^8.0.0
+        version: 8.57.1
+      eslint-plugin-react-hooks:
+        specifier: ^4.6.0
+        version: 4.6.2(eslint@8.57.1)
+      jsdom:
+        specifier: ^22.1.0
+        version: 22.1.0
+      typescript:
+        specifier: ^5.2.0
+        version: 5.9.3
+      vite:
+        specifier: ^5.0.0
+        version: 5.4.21
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@vitest/ui@1.6.1)(jsdom@22.1.0)
 
 packages:
 
@@ -488,6 +549,37 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.9.0':
+    resolution: {integrity: sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/eslintrc@2.1.4':
+    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@eslint/js@8.57.1':
+    resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@humanwhocodes/config-array@0.13.0':
+    resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
+    engines: {node: '>=10.10.0'}
+    deprecated: Use @eslint/config-array instead
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/object-schema@2.0.3':
+    resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
+    deprecated: Use @eslint/object-schema instead
+
   '@jest/schemas@29.6.3':
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -522,6 +614,9 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rolldown/pluginutils@1.0.0-beta.47':
     resolution: {integrity: sha512-8QagwMH3kNCuzD8EWL8R2YPW5e4OrHNSAHRFDdmFqEwEaD/KcNKjVoumo+gP2vW5eKB2UPbM6vTYiGZX0ixLnw==}
@@ -651,9 +746,20 @@ packages:
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
 
+  '@testing-library/dom@9.3.4':
+    resolution: {integrity: sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==}
+    engines: {node: '>=14'}
+
   '@testing-library/jest-dom@6.9.1':
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@14.3.1':
+    resolution: {integrity: sha512-H99XjUhWQw0lTgyMN05W3xQG1Nh4lq574D8keFf1dDoNTJgp66VbJozRaczoF+wsiaPJNt/TcnfpLGufGxSrZQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: ^18.0.0
 
   '@testing-library/react@15.0.7':
     resolution: {integrity: sha512-cg0RvEdD1TIhhkm1IeYMQxrzy0MtUNfa3minv4MjbgcYzJAZ7yD0i0lwoPOTPr+INtiXFezt2o8xMSnyHhEn2Q==}
@@ -671,6 +777,10 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
+
+  '@tootallnate/once@2.0.0':
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -690,6 +800,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
@@ -700,6 +813,76 @@ packages:
 
   '@types/react@18.3.27':
     resolution: {integrity: sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+
+  '@typescript-eslint/eslint-plugin@6.21.0':
+    resolution: {integrity: sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/parser@6.21.0':
+    resolution: {integrity: sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/scope-manager@6.21.0':
+    resolution: {integrity: sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript-eslint/type-utils@6.21.0':
+    resolution: {integrity: sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/types@6.21.0':
+    resolution: {integrity: sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@typescript-eslint/typescript-estree@6.21.0':
+    resolution: {integrity: sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@typescript-eslint/utils@6.21.0':
+    resolution: {integrity: sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+
+  '@typescript-eslint/visitor-keys@6.21.0':
+    resolution: {integrity: sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitejs/plugin-react@5.1.1':
     resolution: {integrity: sha512-WQfkSw0QbQ5aJ2CHYw23ZGkqnRwqKHD/KYsMeTkZzPT4Jcf0DcBxBtwMJxnu6E7oxw5+JC6ZAiePgh28uJ1HBA==}
@@ -727,6 +910,15 @@ packages:
   '@vitest/utils@1.6.1':
     resolution: {integrity: sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==}
 
+  abab@2.0.6:
+    resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
+    deprecated: Use your platform's native atob() and btoa() methods instead
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
@@ -736,17 +928,34 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv@6.12.6:
+    resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.1.3:
+    resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -755,14 +964,29 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  array-buffer-byte-length@1.0.2:
+    resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
+    engines: {node: '>= 0.4'}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
   assertion-error@1.1.0:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
+
   axios@1.13.2:
     resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   baseline-browser-mapping@2.8.30:
     resolution: {integrity: sha512-aTUKW4ptQhS64+v2d6IkPzymEzzhw+G0bA1g3uBRV3+ntkH+svttKseW5IOR4Ed6NUVKqnY7qT3dKvzQ7io4AA==}
@@ -770,6 +994,12 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -788,6 +1018,18 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  callsites@3.1.0:
+    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
   caniuse-lite@1.0.30001756:
     resolution: {integrity: sha512-4HnCNKbMLkLdhJz3TToeVWHSnfJvPaq6vu/eRP0Ahub/07n484XHhBF5AJoSGHdVrS8tKFauUQz8Bp9P7LVx7A==}
 
@@ -795,12 +1037,26 @@ packages:
     resolution: {integrity: sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==}
     engines: {node: '>=4'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -819,12 +1075,20 @@ packages:
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
+  cssstyle@3.0.0:
+    resolution: {integrity: sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==}
+    engines: {node: '>=14'}
+
   cssstyle@5.3.3:
     resolution: {integrity: sha512-OytmFH+13/QXONJcC75QNdMtKpceNk3u8ThBjyyYjkEcy/ekBwR1mMAuNvi3gdBPW3N5TlCzQ0WZw8H0lN/bDw==}
     engines: {node: '>=20'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@4.0.0:
+    resolution: {integrity: sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==}
+    engines: {node: '>=14'}
 
   data-urls@6.0.0:
     resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
@@ -846,6 +1110,21 @@ packages:
     resolution: {integrity: sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==}
     engines: {node: '>=6'}
 
+  deep-equal@2.2.3:
+    resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
+    engines: {node: '>= 0.4'}
+
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -858,11 +1137,24 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+
+  doctrine@3.0.0:
+    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
+    engines: {node: '>=6.0.0'}
+
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  domexception@4.0.0:
+    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
+    engines: {node: '>=12'}
+    deprecated: Use your platform's native DOMException instead
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -882,6 +1174,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-get-iterator@1.1.3:
+    resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -905,16 +1200,69 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-plugin-react-hooks@4.6.2:
+    resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+
+  eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint@8.57.1:
+    resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
+    hasBin: true
+
+  espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  esquery@1.6.0:
+    resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -931,9 +1279,21 @@ packages:
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
+  file-entry-cache@6.0.1:
+    resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
+    engines: {node: ^10.12.0 || >=12.0.0}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@3.2.0:
+    resolution: {integrity: sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==}
+    engines: {node: ^10.12.0 || >=12.0.0}
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
@@ -947,9 +1307,16 @@ packages:
       debug:
         optional: true
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -958,6 +1325,9 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  functions-have-names@1.2.3:
+    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -982,9 +1352,39 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
+
+  globals@13.24.0:
+    resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
+    engines: {node: '>=8'}
+
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  graphemer@1.4.0:
+    resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  has-bigints@1.1.0:
+    resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
+    engines: {node: '>= 0.4'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -998,13 +1398,25 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  html-encoding-sniffer@3.0.0:
+    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
+    engines: {node: '>=12'}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
 
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -1018,9 +1430,56 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  import-fresh@3.3.1:
+    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  internal-slot@1.1.0:
+    resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
+    engines: {node: '>= 0.4'}
+
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
+  is-array-buffer@3.0.5:
+    resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
+    engines: {node: '>= 0.4'}
+
+  is-bigint@1.1.0:
+    resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
+    engines: {node: '>= 0.4'}
+
+  is-boolean-object@1.2.2:
+    resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
+    engines: {node: '>= 0.4'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
+
+  is-date-object@1.1.0:
+    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
+    engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1030,16 +1489,59 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-map@2.0.3:
+    resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
+    engines: {node: '>= 0.4'}
+
+  is-number-object@1.1.1:
+    resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
+    engines: {node: '>= 0.4'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-path-inside@3.0.3:
+    resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
+    engines: {node: '>=8'}
+
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-set@2.0.3:
+    resolution: {integrity: sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==}
+    engines: {node: '>= 0.4'}
+
+  is-shared-array-buffer@1.0.4:
+    resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
+    engines: {node: '>= 0.4'}
 
   is-stream@3.0.0:
     resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  is-string@1.1.1:
+    resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
+    engines: {node: '>= 0.4'}
+
+  is-symbol@1.1.1:
+    resolution: {integrity: sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakmap@2.0.2:
+    resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
+    engines: {node: '>= 0.4'}
+
+  is-weakset@2.0.4:
+    resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
+    engines: {node: '>= 0.4'}
+
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1049,6 +1551,19 @@ packages:
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsdom@22.1.0:
+    resolution: {integrity: sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsdom@27.2.0:
     resolution: {integrity: sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==}
@@ -1064,14 +1579,37 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
 
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
+
   local-pkg@0.5.1:
     resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
     engines: {node: '>=14'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -1128,6 +1666,13 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+
+  minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
@@ -1143,6 +1688,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -1150,16 +1698,65 @@ packages:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  nwsapi@2.2.22:
+    resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   onetime@6.0.0:
     resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
     engines: {node: '>=12'}
+
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
 
   p-limit@5.0.0:
     resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
     engines: {node: '>=18'}
 
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  parent-module@1.0.1:
+    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
+    engines: {node: '>=6'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1168,6 +1765,10 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -1192,9 +1793,17 @@ packages:
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -1207,9 +1816,15 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -1225,6 +1840,10 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
@@ -1237,21 +1856,44 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  regexp.prototype.flags@1.5.4:
+    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
+    engines: {node: '>= 0.4'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  resolve-from@4.0.0:
+    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
+    engines: {node: '>=4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
 
   rollup@4.53.3:
     resolution: {integrity: sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.6.0:
+    resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
@@ -1267,6 +1909,19 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
+  semver@7.7.3:
+    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
+  set-function-name@2.0.2:
+    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
+    engines: {node: '>= 0.4'}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -1274,6 +1929,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -1286,6 +1957,10 @@ packages:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
 
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1296,6 +1971,14 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  stop-iteration-iterator@1.1.0:
+    resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
+    engines: {node: '>= 0.4'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
@@ -1304,11 +1987,22 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  text-table@0.2.0:
+    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1340,17 +2034,39 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
   tough-cookie@6.0.0:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
+
+  tr46@4.1.1:
+    resolution: {integrity: sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==}
+    engines: {node: '>=14'}
 
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
 
+  ts-api-utils@1.4.3:
+    resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
+
+  type-fest@0.20.2:
+    resolution: {integrity: sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==}
+    engines: {node: '>=10'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1360,11 +2076,26 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   update-browserslist-db@1.1.4:
     resolution: {integrity: sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   vite-node@1.6.1:
     resolution: {integrity: sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==}
@@ -1467,25 +2198,57 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@4.0.0:
+    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
+    engines: {node: '>=14'}
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
 
   webidl-conversions@8.0.0:
     resolution: {integrity: sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==}
     engines: {node: '>=20'}
 
+  whatwg-encoding@2.0.0:
+    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
+    engines: {node: '>=12'}
+
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
 
+  whatwg-url@12.0.1:
+    resolution: {integrity: sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==}
+    engines: {node: '>=14'}
+
   whatwg-url@15.1.0:
     resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
     engines: {node: '>=20'}
+
+  which-boxed-primitive@1.1.1:
+    resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
+    engines: {node: '>= 0.4'}
+
+  which-collection@1.0.2:
+    resolution: {integrity: sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==}
+    engines: {node: '>= 0.4'}
+
+  which-typed-array@1.1.19:
+    resolution: {integrity: sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==}
+    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -1496,6 +2259,13 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
@@ -1509,6 +2279,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -1519,9 +2293,31 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
   zustand@5.0.8:
     resolution: {integrity: sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==}
@@ -1848,6 +2644,41 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.0(eslint@8.57.1)':
+    dependencies:
+      eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/eslintrc@2.1.4':
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.3
+      espree: 9.6.1
+      globals: 13.24.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/js@8.57.1': {}
+
+  '@humanwhocodes/config-array@0.13.0':
+    dependencies:
+      '@humanwhocodes/object-schema': 2.0.3
+      debug: 4.4.3
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/object-schema@2.0.3': {}
+
   '@jest/schemas@29.6.3':
     dependencies:
       '@sinclair/typebox': 0.27.8
@@ -1884,6 +2715,8 @@ snapshots:
       fastq: 1.19.1
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rolldown/pluginutils@1.0.0-beta.47': {}
 
@@ -1973,6 +2806,17 @@ snapshots:
       picocolors: 1.1.1
       pretty-format: 27.5.1
 
+  '@testing-library/dom@9.3.4':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.1.3
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
   '@testing-library/jest-dom@6.9.1':
     dependencies:
       '@adobe/css-tools': 4.4.4
@@ -1981,6 +2825,16 @@ snapshots:
       dom-accessibility-api: 0.6.3
       picocolors: 1.1.1
       redent: 3.0.0
+
+  '@testing-library/react@14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 9.3.4
+      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@testing-library/react@15.0.7(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -1995,6 +2849,8 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
+
+  '@tootallnate/once@2.0.0': {}
 
   '@types/aria-query@5.0.4': {}
 
@@ -2021,6 +2877,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/json-schema@7.0.15': {}
+
   '@types/prop-types@15.7.15': {}
 
   '@types/react-dom@18.3.7(@types/react@18.3.27)':
@@ -2031,6 +2889,108 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/semver@7.7.1': {}
+
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.4.3
+      eslint: 8.57.1
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      semver: 7.7.3
+      ts-api-utils: 1.4.3(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.4.3
+      eslint: 8.57.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@6.21.0':
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+
+  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 8.57.1
+      ts-api-utils: 1.4.3(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@6.21.0': {}
+
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.4.3
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.7.3
+      ts-api-utils: 1.4.3(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.7.1
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.9.3)
+      eslint: 8.57.1
+      semver: 7.7.3
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@typescript-eslint/visitor-keys@6.21.0':
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      eslint-visitor-keys: 3.4.3
+
+  '@ungap/structured-clone@1.3.0': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21)':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 5.4.21
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitejs/plugin-react@5.1.1(vite@7.2.4)':
     dependencies:
@@ -2075,7 +3035,7 @@ snapshots:
       pathe: 1.1.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      vitest: 1.6.1(@vitest/ui@1.6.1)(jsdom@27.2.0)
+      vitest: 1.6.1(@vitest/ui@1.6.1)(jsdom@22.1.0)
 
   '@vitest/utils@1.6.1':
     dependencies:
@@ -2084,17 +3044,46 @@ snapshots:
       loupe: 2.3.7
       pretty-format: 29.7.0
 
+  abab@2.0.6: {}
+
+  acorn-jsx@5.3.2(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ansi-regex@5.0.1: {}
 
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   ansi-styles@5.2.0: {}
+
+  argparse@2.0.1: {}
+
+  aria-query@5.1.3:
+    dependencies:
+      deep-equal: 2.2.3
 
   aria-query@5.3.0:
     dependencies:
@@ -2102,9 +3091,20 @@ snapshots:
 
   aria-query@5.3.2: {}
 
+  array-buffer-byte-length@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      is-array-buffer: 3.0.5
+
+  array-union@2.1.0: {}
+
   assertion-error@1.1.0: {}
 
   asynckit@0.4.0: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
 
   axios@1.13.2:
     dependencies:
@@ -2114,11 +3114,22 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  balanced-match@1.0.2: {}
+
   baseline-browser-mapping@2.8.30: {}
 
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   braces@3.0.3:
     dependencies:
@@ -2139,6 +3150,20 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  callsites@3.1.0: {}
+
   caniuse-lite@1.0.30001756: {}
 
   chai@4.5.0:
@@ -2151,13 +3176,26 @@ snapshots:
       pathval: 1.1.1
       type-detect: 4.1.0
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
 
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
 
@@ -2176,6 +3214,10 @@ snapshots:
 
   css.escape@1.5.1: {}
 
+  cssstyle@3.0.0:
+    dependencies:
+      rrweb-cssom: 0.6.0
+
   cssstyle@5.3.3:
     dependencies:
       '@asamuzakjp/css-color': 4.1.0
@@ -2183,6 +3225,12 @@ snapshots:
       css-tree: 3.1.0
 
   csstype@3.2.3: {}
+
+  data-urls@4.0.0:
+    dependencies:
+      abab: 2.0.6
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 12.0.1
 
   data-urls@6.0.0:
     dependencies:
@@ -2199,15 +3247,62 @@ snapshots:
     dependencies:
       type-detect: 4.1.0
 
+  deep-equal@2.2.3:
+    dependencies:
+      array-buffer-byte-length: 1.0.2
+      call-bind: 1.0.8
+      es-get-iterator: 1.1.3
+      get-intrinsic: 1.3.0
+      is-arguments: 1.2.0
+      is-array-buffer: 3.0.5
+      is-date-object: 1.1.0
+      is-regex: 1.2.1
+      is-shared-array-buffer: 1.0.4
+      isarray: 2.0.5
+      object-is: 1.1.6
+      object-keys: 1.1.1
+      object.assign: 4.1.7
+      regexp.prototype.flags: 1.5.4
+      side-channel: 1.1.0
+      which-boxed-primitive: 1.1.1
+      which-collection: 1.0.2
+      which-typed-array: 1.1.19
+
+  deep-is@0.1.4: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
+
   delayed-stream@1.0.0: {}
 
   dequal@2.0.3: {}
 
   diff-sequences@29.6.3: {}
 
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
+
+  doctrine@3.0.0:
+    dependencies:
+      esutils: 2.0.3
+
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  domexception@4.0.0:
+    dependencies:
+      webidl-conversions: 7.0.0
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2222,6 +3317,18 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-get-iterator@1.1.3:
+    dependencies:
+      call-bind: 1.0.8
+      get-intrinsic: 1.3.0
+      has-symbols: 1.1.0
+      is-arguments: 1.2.0
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-string: 1.1.1
+      isarray: 2.0.5
+      stop-iteration-iterator: 1.1.0
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -2291,9 +3398,83 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-react-hooks@4.6.2(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+
+  eslint-scope@7.2.2:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint@8.57.1:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/eslintrc': 2.1.4
+      '@eslint/js': 8.57.1
+      '@humanwhocodes/config-array': 0.13.0
+      '@humanwhocodes/module-importer': 1.0.1
+      '@nodelib/fs.walk': 1.2.8
+      '@ungap/structured-clone': 1.3.0
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      doctrine: 3.0.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 6.0.1
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      globals: 13.24.0
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      is-path-inside: 3.0.3
+      js-yaml: 4.1.1
+      json-stable-stringify-without-jsonify: 1.0.1
+      levn: 0.4.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+      strip-ansi: 6.0.1
+      text-table: 0.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@9.6.1:
+    dependencies:
+      acorn: 8.15.0
+      acorn-jsx: 5.3.2(acorn@8.15.0)
+      eslint-visitor-keys: 3.4.3
+
+  esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  esutils@2.0.3: {}
 
   execa@8.0.1:
     dependencies:
@@ -2307,6 +3488,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  fast-deep-equal@3.1.3: {}
+
   fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2314,6 +3497,10 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
 
   fastq@1.19.1:
     dependencies:
@@ -2325,13 +3512,32 @@ snapshots:
 
   fflate@0.8.2: {}
 
+  file-entry-cache@6.0.1:
+    dependencies:
+      flat-cache: 3.2.0
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@3.2.0:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+      rimraf: 3.0.2
+
   flatted@3.3.3: {}
 
   follow-redirects@1.15.11: {}
+
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
 
   form-data@4.0.5:
     dependencies:
@@ -2341,10 +3547,14 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  fs.realpath@1.0.0: {}
+
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
+
+  functions-have-names@1.2.3: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -2374,7 +3584,43 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  globals@13.24.0:
+    dependencies:
+      type-fest: 0.20.2
+
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
+
   gopd@1.2.0: {}
+
+  graphemer@1.4.0: {}
+
+  has-bigints@1.1.0: {}
+
+  has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
 
   has-symbols@1.1.0: {}
 
@@ -2386,13 +3632,32 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-encoding-sniffer@3.0.0:
+    dependencies:
+      whatwg-encoding: 2.0.0
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
 
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -2410,7 +3675,56 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ignore@5.3.2: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
   indent-string@4.0.0: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  internal-slot@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      hasown: 2.0.2
+      side-channel: 1.1.0
+
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-array-buffer@3.0.5:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  is-bigint@1.1.0:
+    dependencies:
+      has-bigints: 1.1.0
+
+  is-boolean-object@1.2.2:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-callable@1.2.7: {}
+
+  is-date-object@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
 
   is-extglob@2.1.1: {}
 
@@ -2418,17 +3732,93 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-map@2.0.3: {}
+
+  is-number-object@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-number@7.0.0: {}
+
+  is-path-inside@3.0.3: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
+
+  is-set@2.0.3: {}
+
+  is-shared-array-buffer@1.0.4:
+    dependencies:
+      call-bound: 1.0.4
+
   is-stream@3.0.0: {}
+
+  is-string@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
+  is-symbol@1.1.1:
+    dependencies:
+      call-bound: 1.0.4
+      has-symbols: 1.1.0
+      safe-regex-test: 1.1.0
+
+  is-weakmap@2.0.2: {}
+
+  is-weakset@2.0.4:
+    dependencies:
+      call-bound: 1.0.4
+      get-intrinsic: 1.3.0
+
+  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  jsdom@22.1.0:
+    dependencies:
+      abab: 2.0.6
+      cssstyle: 3.0.0
+      data-urls: 4.0.0
+      decimal.js: 10.6.0
+      domexception: 4.0.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 3.0.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.22
+      parse5: 7.3.0
+      rrweb-cssom: 0.6.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 4.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 12.0.1
+      ws: 8.18.3
+      xml-name-validator: 4.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsdom@27.2.0:
     dependencies:
@@ -2459,12 +3849,33 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
   json5@2.2.3: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   local-pkg@0.5.1:
     dependencies:
       mlly: 1.8.0
       pkg-types: 1.3.1
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
 
   loose-envify@1.4.0:
     dependencies:
@@ -2509,6 +3920,14 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.12
+
+  minimatch@9.0.3:
+    dependencies:
+      brace-expansion: 2.0.2
+
   mlly@1.8.0:
     dependencies:
       acorn: 8.15.0
@@ -2522,27 +3941,84 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  natural-compare@1.4.0: {}
+
   node-releases@2.0.27: {}
 
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
 
+  nwsapi@2.2.22: {}
+
+  object-inspect@1.13.4: {}
+
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.1
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   onetime@6.0.0:
     dependencies:
       mimic-fn: 4.0.0
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
 
   p-limit@5.0.0:
     dependencies:
       yocto-queue: 1.2.2
 
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
 
+  path-exists@4.0.0: {}
+
+  path-is-absolute@1.0.1: {}
+
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-type@4.0.0: {}
 
   pathe@1.1.2: {}
 
@@ -2562,11 +4038,15 @@ snapshots:
       mlly: 1.8.0
       pathe: 2.0.3
 
+  possible-typed-array-names@1.1.0: {}
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  prelude-ls@1.2.1: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -2582,7 +4062,13 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   punycode@2.3.1: {}
+
+  querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -2596,6 +4082,8 @@ snapshots:
 
   react-is@18.3.1: {}
 
+  react-refresh@0.17.0: {}
+
   react-refresh@0.18.0: {}
 
   react@18.3.1:
@@ -2607,9 +4095,26 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  regexp.prototype.flags@1.5.4:
+    dependencies:
+      call-bind: 1.0.8
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      set-function-name: 2.0.2
+
   require-from-string@2.0.2: {}
 
+  requires-port@1.0.0: {}
+
+  resolve-from@4.0.0: {}
+
   reusify@1.1.0: {}
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
 
   rollup@4.53.3:
     dependencies:
@@ -2639,9 +4144,17 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.53.3
       fsevents: 2.3.3
 
+  rrweb-cssom@0.6.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
 
@@ -2655,11 +4168,57 @@ snapshots:
 
   semver@6.3.1: {}
 
+  semver@7.7.3: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
+
+  set-function-name@2.0.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      functions-have-names: 1.2.3
+      has-property-descriptors: 1.0.2
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
@@ -2671,11 +4230,22 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  slash@3.0.0: {}
+
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  stop-iteration-iterator@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      internal-slot: 1.1.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-final-newline@3.0.0: {}
 
@@ -2683,11 +4253,19 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strip-json-comments@3.1.1: {}
+
   strip-literal@2.1.1:
     dependencies:
       js-tokens: 9.0.1
 
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
   symbol-tree@3.2.4: {}
+
+  text-table@0.2.0: {}
 
   tinybench@2.9.0: {}
 
@@ -2712,25 +4290,61 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.18
+
+  tr46@4.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
 
+  ts-api-utils@1.4.3(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
   type-detect@4.1.0: {}
+
+  type-fest@0.20.2: {}
 
   typescript@5.9.3: {}
 
   ufo@1.6.1: {}
+
+  universalify@0.2.0: {}
 
   update-browserslist-db@1.1.4(browserslist@4.28.0):
     dependencies:
       browserslist: 4.28.0
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
+
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   vite-node@1.6.1:
     dependencies:
@@ -2769,6 +4383,41 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  vitest@1.6.1(@vitest/ui@1.6.1)(jsdom@22.1.0):
+    dependencies:
+      '@vitest/expect': 1.6.1
+      '@vitest/runner': 1.6.1
+      '@vitest/snapshot': 1.6.1
+      '@vitest/spy': 1.6.1
+      '@vitest/utils': 1.6.1
+      acorn-walk: 8.3.4
+      chai: 4.5.0
+      debug: 4.4.3
+      execa: 8.0.1
+      local-pkg: 0.5.1
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      std-env: 3.10.0
+      strip-literal: 2.1.1
+      tinybench: 2.9.0
+      tinypool: 0.8.4
+      vite: 5.4.21
+      vite-node: 1.6.1
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@vitest/ui': 1.6.1(vitest@1.6.1)
+      jsdom: 22.1.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vitest@1.6.1(@vitest/ui@1.6.1)(jsdom@27.2.0):
     dependencies:
       '@vitest/expect': 1.6.1
@@ -2804,22 +4453,64 @@ snapshots:
       - supports-color
       - terser
 
+  w3c-xmlserializer@4.0.0:
+    dependencies:
+      xml-name-validator: 4.0.0
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
 
+  webidl-conversions@7.0.0: {}
+
   webidl-conversions@8.0.0: {}
+
+  whatwg-encoding@2.0.0:
+    dependencies:
+      iconv-lite: 0.6.3
 
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
 
+  whatwg-mimetype@3.0.0: {}
+
   whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@12.0.1:
+    dependencies:
+      tr46: 4.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@15.1.0:
     dependencies:
       tr46: 6.0.0
       webidl-conversions: 8.0.0
+
+  which-boxed-primitive@1.1.1:
+    dependencies:
+      is-bigint: 1.1.0
+      is-boolean-object: 1.2.2
+      is-number-object: 1.1.1
+      is-string: 1.1.1
+      is-symbol: 1.1.1
+
+  which-collection@1.0.2:
+    dependencies:
+      is-map: 2.0.3
+      is-set: 2.0.3
+      is-weakmap: 2.0.2
+      is-weakset: 2.0.4
+
+  which-typed-array@1.1.19:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:
@@ -2830,7 +4521,13 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  word-wrap@1.2.5: {}
+
+  wrappy@1.0.2: {}
+
   ws@8.18.3: {}
+
+  xml-name-validator@4.0.0: {}
 
   xml-name-validator@5.0.0: {}
 
@@ -2838,9 +4535,21 @@ snapshots:
 
   yallist@3.1.1: {}
 
+  yocto-queue@0.1.0: {}
+
   yocto-queue@1.2.2: {}
 
-  zustand@5.0.8(@types/react@18.3.27)(react@18.3.1):
+  zod@3.25.76: {}
+
+  zustand@4.5.7(@types/react@18.3.27)(react@18.3.1):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.27
       react: 18.3.1
+
+  zustand@5.0.8(@types/react@18.3.27)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)):
+    optionalDependencies:
+      '@types/react': 18.3.27
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - frontend
+
+onlyBuiltDependencies:
+  - esbuild

--- a/scripts/generate_figma_tokens.py
+++ b/scripts/generate_figma_tokens.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+"""
+Generate Figma design tokens JSON from a simple token JSON file.
+
+Input JSON shape (list or { "tokens": [...] }):
+[
+  {
+    "name": "primary",
+    "path": ["color", "brand"],
+    "token_type": "color",
+    "w3c_type": "color",
+    "value": "#FF6B35",
+    "confidence": 0.95,
+    "description": "Primary brand color"
+  }
+]
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from copy_that.pipeline import TokenResult, TokenType, W3CTokenType
+from copy_that.pipeline.generator.agent import GeneratorAgent, OutputFormat
+
+
+def load_tokens(input_path: Path) -> list[TokenResult]:
+    raw = json.loads(input_path.read_text())
+    items: list[dict[str, Any]] = (
+        raw["tokens"] if isinstance(raw, dict) and "tokens" in raw else raw
+    )
+    tokens: list[TokenResult] = []
+    for item in items:
+        tokens.append(
+            TokenResult(
+                token_type=TokenType(item["token_type"]),
+                name=item["name"],
+                path=item.get("path", []),
+                w3c_type=W3CTokenType(item["w3c_type"]) if item.get("w3c_type") else None,
+                value=item["value"],
+                description=item.get("description"),
+                reference=item.get("reference"),
+                confidence=float(item.get("confidence", 1.0)),
+                extensions=item.get("extensions"),
+                metadata=item.get("metadata"),
+            )
+        )
+    return tokens
+
+
+def generate_figma(input_path: Path, output_path: Path) -> None:
+    tokens = load_tokens(input_path)
+    agent = GeneratorAgent(output_format=OutputFormat.FIGMA)
+    output = agent._env.get_template("figma.j2").render(
+        tokens=tokens, token_tree={}, format="figma"
+    )  # noqa: SLF001
+    output_path.write_text(output)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate Figma tokens JSON from token list.")
+    parser.add_argument("--input", required=True, help="Path to input token JSON")
+    parser.add_argument("--output", required=True, help="Path to write figma JSON")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    generate_figma(input_path, output_path)
+    print(f"Figma tokens written to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/copy_that/application/cv/color_cv_extractor.py
+++ b/src/copy_that/application/cv/color_cv_extractor.py
@@ -1,0 +1,113 @@
+"""
+Lightweight CV-first color extractor using Pillow + coloraide.
+
+Goal: fast local palette for immediate UI render, later refined by AI.
+"""
+
+from __future__ import annotations
+
+import io
+from collections import Counter
+
+from coloraide import Color
+from PIL import Image
+
+from copy_that.application.color_extractor import ColorExtractionResult, ExtractedColorToken
+
+
+class CVColorExtractor:
+    """Quick palette extraction without remote AI."""
+
+    def __init__(self, max_colors: int = 8):
+        self.max_colors = max_colors
+
+    def extract_from_bytes(self, data: bytes) -> ColorExtractionResult:
+        image = Image.open(io.BytesIO(data)).convert("RGB")
+        # Quantize to palette for speed
+        paletted = image.convert("P", palette=Image.ADAPTIVE, colors=min(self.max_colors * 2, 24))
+        palette = paletted.getpalette()
+        color_counts = paletted.getcolors()
+        if not color_counts:
+            return self._empty()
+
+        # Map palette index to RGB
+        def idx_to_rgb(idx: int) -> tuple[int, int, int]:
+            base = idx * 3
+            return palette[base], palette[base + 1], palette[base + 2]
+
+        rgb_counts = Counter()
+        for count, idx in color_counts:
+            rgb_counts[idx_to_rgb(idx)] += count
+
+        top = rgb_counts.most_common(self.max_colors)
+        tokens: list[ExtractedColorToken] = []
+        total = sum(rgb_counts.values()) or 1
+        for rgb, count in top:
+            hex_val = "#{:02x}{:02x}{:02x}".format(*rgb)
+            c = Color(hex_val)
+            name = c.to("css3").to_string() if hasattr(c, "to") else hex_val
+            prominence = round(count / total * 100, 2)
+            tokens.append(
+                ExtractedColorToken(
+                    hex=hex_val,
+                    rgb=f"rgb{rgb}",
+                    hsl=c.convert("hsl").to_string() if hasattr(c, "convert") else None,
+                    hsv=None,
+                    name=name,
+                    design_intent=None,
+                    semantic_names=None,
+                    category="cv",
+                    confidence=0.6,
+                    harmony=None,
+                    temperature=None,
+                    saturation_level=None,
+                    lightness_level=None,
+                    usage=[],
+                    count=1,
+                    prominence_percentage=prominence,
+                    wcag_contrast_on_white=None,
+                    wcag_contrast_on_black=None,
+                    wcag_aa_compliant_text=None,
+                    wcag_aaa_compliant_text=None,
+                    wcag_aa_compliant_normal=None,
+                    wcag_aaa_compliant_normal=None,
+                    colorblind_safe=None,
+                    tint_color=None,
+                    shade_color=None,
+                    tone_color=None,
+                    closest_web_safe=None,
+                    closest_css_named=None,
+                    delta_e_to_dominant=None,
+                    is_neutral=c.is_achromatic() if hasattr(c, "is_achromatic") else None,
+                    kmeans_cluster_id=None,
+                    sam_segmentation_mask=None,
+                    clip_embeddings=None,
+                    extraction_metadata={"source": "cv", "palette_count": len(top)},
+                    histogram_significance=prominence / 100.0,
+                )
+            )
+
+        dominant = [t.hex for t in tokens[:3]]
+        return ColorExtractionResult(
+            colors=tokens,
+            dominant_colors=dominant,
+            color_palette="CV palette",
+            extraction_confidence=0.6,
+            extractor_used="cv",
+        )
+
+    def extract_from_base64(self, image_base64: str) -> ColorExtractionResult:
+        import base64
+
+        data = base64.b64decode(image_base64.split(",")[1] if "," in image_base64 else image_base64)
+        return self.extract_from_bytes(data)
+
+    @staticmethod
+    def _empty() -> ColorExtractionResult:
+        return ColorExtractionResult(
+            colors=[],
+            dominant_colors=[],
+            color_palette="",
+            extraction_confidence=0.0,
+            extractor_used="cv",
+        )

--- a/src/copy_that/application/cv/color_cv_extractor.py
+++ b/src/copy_that/application/cv/color_cv_extractor.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import io
 from collections import Counter
+from collections import Counter as CounterType
 
 from coloraide import Color
 from PIL import Image
@@ -26,6 +27,8 @@ class CVColorExtractor:
         # Quantize to palette for speed
         paletted = image.convert("P", palette=Image.ADAPTIVE, colors=min(self.max_colors * 2, 24))
         palette = paletted.getpalette()
+        if palette is None:
+            return self._empty()
         color_counts = paletted.getcolors()
         if not color_counts:
             return self._empty()
@@ -35,7 +38,7 @@ class CVColorExtractor:
             base = idx * 3
             return palette[base], palette[base + 1], palette[base + 2]
 
-        rgb_counts = Counter()
+        rgb_counts: CounterType[tuple[int, int, int]] = Counter()
         for count, idx in color_counts:
             rgb_counts[idx_to_rgb(idx)] += count
 

--- a/src/copy_that/application/cv/spacing_cv_extractor.py
+++ b/src/copy_that/application/cv/spacing_cv_extractor.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import base64
 from collections import Counter
+from collections.abc import Iterable
 
 import cv2
 import numpy as np
@@ -90,9 +91,9 @@ class CVSpacingExtractor:
         return self.extract_from_bytes(data)
 
     @staticmethod
-    def _measure_gaps(bboxes):
-        x_gaps = []
-        y_gaps = []
+    def _measure_gaps(bboxes: Iterable[tuple[int, int, int, int]]) -> tuple[list[int], list[int]]:
+        x_gaps: list[int] = []
+        y_gaps: list[int] = []
         sorted_x = sorted(bboxes, key=lambda b: b[0])
         sorted_y = sorted(bboxes, key=lambda b: b[1])
         for i in range(len(sorted_x) - 1):

--- a/src/copy_that/application/cv/spacing_cv_extractor.py
+++ b/src/copy_that/application/cv/spacing_cv_extractor.py
@@ -1,0 +1,166 @@
+"""
+Lightweight CV-first spacing extractor (OpenCV gap analysis).
+
+Adds prominence metadata and base unit/scale info for UI display.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections import Counter
+
+import cv2
+import numpy as np
+
+from copy_that.application.spacing_models import (
+    SpacingExtractionResult,
+    SpacingScale,
+    SpacingToken,
+)
+
+
+class CVSpacingExtractor:
+    """Fast spacing inference without remote AI."""
+
+    def __init__(self, max_tokens: int = 12):
+        self.max_tokens = max_tokens
+
+    def extract_from_bytes(self, data: bytes) -> SpacingExtractionResult:
+        img_array = np.frombuffer(data, np.uint8)
+        img = cv2.imdecode(img_array, cv2.IMREAD_GRAYSCALE)
+        if img is None:
+            return self._fallback()
+
+        edges = cv2.Canny(img, 50, 150)
+        contours, _ = cv2.findContours(edges, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+        if not contours:
+            return self._fallback()
+
+        bboxes = [cv2.boundingRect(c) for c in contours]
+        if len(bboxes) < 2:
+            return self._fallback()
+
+        x_gaps, y_gaps = self._measure_gaps(bboxes)
+        all_gaps = x_gaps + y_gaps
+        if not all_gaps:
+            return self._fallback()
+
+        quantized = [self._quantize(g) for g in all_gaps if g > 0]
+        counts = Counter(quantized)
+        common = counts.most_common(self.max_tokens)
+        values = sorted(set([v for v, _ in common]))[: self.max_tokens]
+        if not values:
+            return self._fallback()
+
+        base_unit = self._detect_base_unit(values)
+        tokens: list[SpacingToken] = []
+        for i, (label, v) in enumerate(zip(self._labels(), values, strict=False)):
+            prominence = counts.get(v, 1) / max(len(all_gaps), 1)
+            tokens.append(
+                SpacingToken(
+                    value_px=int(v),
+                    name=f"spacing-{label}",
+                    semantic_role="layout",
+                    spacing_type=None,
+                    category="cv",
+                    confidence=0.55 + (0.1 * min(prominence, 0.3)),
+                    usage=["layout"],
+                    scale_position=i,
+                    base_unit=base_unit,
+                    scale_system=self._scale_from_base(base_unit),
+                    grid_aligned=base_unit > 0 and v % base_unit == 0,
+                    prominence_percentage=round(prominence * 100, 2),
+                    extraction_metadata={"source": "cv"},
+                )
+            )
+
+        return SpacingExtractionResult(
+            tokens=tokens,
+            scale_system=self._scale_from_base(base_unit),
+            base_unit=base_unit,
+            grid_compliance=1.0 if base_unit else 0.5,
+            extraction_confidence=0.55,
+            min_spacing=min(values),
+            max_spacing=max(values),
+            unique_values=values,
+        )
+
+    def extract_from_base64(self, image_base64: str) -> SpacingExtractionResult:
+        data = base64.b64decode(image_base64.split(",")[1] if "," in image_base64 else image_base64)
+        return self.extract_from_bytes(data)
+
+    @staticmethod
+    def _measure_gaps(bboxes):
+        x_gaps = []
+        y_gaps = []
+        sorted_x = sorted(bboxes, key=lambda b: b[0])
+        sorted_y = sorted(bboxes, key=lambda b: b[1])
+        for i in range(len(sorted_x) - 1):
+            _, _, w1, _ = sorted_x[i]
+            x1 = sorted_x[i][0] + w1
+            x2 = sorted_x[i + 1][0]
+            gap = x2 - x1
+            if 2 <= gap <= 200:
+                x_gaps.append(gap)
+        for i in range(len(sorted_y) - 1):
+            _, _, _, h1 = sorted_y[i]
+            y1 = sorted_y[i][1] + h1
+            y2 = sorted_y[i + 1][1]
+            gap = y2 - y1
+            if 2 <= gap <= 200:
+                y_gaps.append(gap)
+        return x_gaps, y_gaps
+
+    @staticmethod
+    def _quantize(val: int) -> int:
+        return int(round(val / 4.0) * 4)
+
+    @staticmethod
+    def _detect_base_unit(values: list[int]) -> int:
+        if all(v % 8 == 0 for v in values):
+            return 8
+        if all(v % 4 == 0 for v in values):
+            return 4
+        return 4
+
+    @staticmethod
+    def _scale_from_base(base: int) -> SpacingScale:
+        return SpacingScale.EIGHT_POINT if base >= 8 else SpacingScale.FOUR_POINT
+
+    @staticmethod
+    def _labels() -> list[str]:
+        return ["xs", "sm", "md", "lg", "xl", "xxl", "xxxl", "mega"]
+
+    @staticmethod
+    def _fallback() -> SpacingExtractionResult:
+        defaults = [4, 8, 16, 24, 32, 48]
+        tokens = [
+            SpacingToken(
+                value_px=v,
+                name=f"spacing-{n}",
+                semantic_role="layout",
+                spacing_type=None,
+                category="cv",
+                confidence=0.5,
+                usage=["layout"],
+                scale_position=i,
+                base_unit=4,
+                scale_system=SpacingScale.FOUR_POINT,
+                grid_aligned=True,
+                prominence_percentage=None,
+                extraction_metadata={"source": "cv"},
+            )
+            for i, (n, v) in enumerate(
+                zip(["xs", "sm", "md", "lg", "xl", "xxl"], defaults, strict=False)
+            )
+        ]
+        return SpacingExtractionResult(
+            tokens=tokens,
+            scale_system=SpacingScale.FOUR_POINT,
+            base_unit=4,
+            grid_compliance=1.0,
+            extraction_confidence=0.5,
+            min_spacing=min(defaults),
+            max_spacing=max(defaults),
+            unique_values=defaults,
+        )

--- a/src/copy_that/domain/models.py
+++ b/src/copy_that/domain/models.py
@@ -99,6 +99,38 @@ class Project(Base):
         return f"<Project(id={self.id}, name='{self.name}')>"
 
 
+class SpacingToken(Base):
+    """Spacing token persistence."""
+
+    __tablename__ = "spacing_tokens"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    extraction_job_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    value_px: Mapped[int] = mapped_column(Integer, nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    semantic_role: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    spacing_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    category: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    confidence: Mapped[float] = mapped_column(nullable=False, default=0.0)
+    usage: Mapped[str | None] = mapped_column(Text, nullable=True)  # JSON list
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utc_now, nullable=False)
+
+
+class ProjectSnapshot(Base):
+    """Immutable snapshot of tokens for a project."""
+
+    __tablename__ = "project_snapshots"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    project_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    data: Mapped[str] = mapped_column(Text, nullable=False)  # JSON blob of tokens/meta
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utc_now, nullable=False)
+
+
 class ExtractionJob(Base):
     """An extraction job for processing images/videos/audio"""
 

--- a/src/copy_that/infrastructure/database.py
+++ b/src/copy_that/infrastructure/database.py
@@ -43,6 +43,8 @@ if "sqlite" not in DATABASE_URL:
         query_params = parse_qs(parsed.query)
         # Remove sslmode parameter
         query_params.pop("sslmode", None)
+        # Remove channel_binding parameter (asyncpg <0.31 rejects it)
+        query_params.pop("channel_binding", None)
         # Rebuild URL with remaining parameters
         new_query = urlencode(query_params, doseq=True)
         DATABASE_URL = urlunparse(

--- a/src/copy_that/interfaces/api/colors.py
+++ b/src/copy_that/interfaces/api/colors.py
@@ -153,13 +153,19 @@ async def extract_colors_from_image(
                 request.image_base64
             )
         elif request.image_url:
-            # Download and convert to base64 for CV extractor
-            resp = requests.get(request.image_url, timeout=30)
-            resp.raise_for_status()
-            import base64
+            try:
+                # Download and convert to base64 for CV extractor
+                resp = requests.get(request.image_url, timeout=10)
+                resp.raise_for_status()
+                import base64
 
-            cv_b64 = base64.b64encode(resp.content).decode("utf-8")
-            cv_result = CVColorExtractor(max_colors=request.max_colors).extract_from_base64(cv_b64)
+                cv_b64 = base64.b64encode(resp.content).decode("utf-8")
+                cv_result = CVColorExtractor(max_colors=request.max_colors).extract_from_base64(
+                    cv_b64
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug("CV pre-pass skipped for %s", request.image_url)
+                cv_result = None
 
         # AI refinement
         extractor, extractor_name = get_extractor(request.extractor or "auto")

--- a/src/copy_that/interfaces/api/main.py
+++ b/src/copy_that/interfaces/api/main.py
@@ -19,10 +19,12 @@ from copy_that.infrastructure.database import Base, engine, get_db
 from copy_that.interfaces.api.auth import router as auth_router
 from copy_that.interfaces.api.colors import router as colors_router
 from copy_that.interfaces.api.middleware.security_headers import SecurityHeadersMiddleware
+from copy_that.interfaces.api.multi_extract import router as multi_extract_router
 
 # Import routers
 from copy_that.interfaces.api.projects import router as projects_router
 from copy_that.interfaces.api.sessions import router as sessions_router
+from copy_that.interfaces.api.snapshots import router as snapshots_router
 from copy_that.interfaces.api.spacing import router as spacing_router
 
 
@@ -96,6 +98,8 @@ app.include_router(projects_router)
 app.include_router(colors_router)
 app.include_router(spacing_router)
 app.include_router(sessions_router)
+app.include_router(multi_extract_router)
+app.include_router(snapshots_router)
 
 # Setup Prometheus metrics
 Instrumentator().instrument(app).expose(app, endpoint="/metrics")

--- a/src/copy_that/interfaces/api/middleware/security_headers.py
+++ b/src/copy_that/interfaces/api/middleware/security_headers.py
@@ -28,11 +28,11 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         # Content Security Policy
         response.headers["Content-Security-Policy"] = (
             "default-src 'self'; "
-            "script-src 'self'; "
-            "style-src 'self' 'unsafe-inline'; "
+            "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
+            "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
             "img-src 'self' data: https:; "
-            "font-src 'self'; "
-            "connect-src 'self'"
+            "font-src 'self' https://cdn.jsdelivr.net; "
+            "connect-src 'self' https://cdn.jsdelivr.net"
         )
 
         # HSTS (only in production)

--- a/src/copy_that/interfaces/api/multi_extract.py
+++ b/src/copy_that/interfaces/api/multi_extract.py
@@ -210,7 +210,7 @@ async def _persist_color_tokens(db: AsyncSession, project_id: int, tokens: list[
     await db.commit()
 
 
-async def _persist_spacing_tokens(db: AsyncSession, project_id: int, tokens) -> None:
+async def _persist_spacing_tokens(db: AsyncSession, project_id: int, tokens: list[Any]) -> None:
     job = ExtractionJob(
         project_id=project_id,
         source_url="multi-extract",

--- a/src/copy_that/interfaces/api/multi_extract.py
+++ b/src/copy_that/interfaces/api/multi_extract.py
@@ -1,0 +1,253 @@
+"""
+Multi-token extraction with CV-first + AI refinement and SSE streaming.
+"""
+
+import asyncio
+import json
+import logging
+import math
+from collections.abc import AsyncGenerator, Sequence
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from copy_that.application.cv.color_cv_extractor import CVColorExtractor
+from copy_that.application.cv.spacing_cv_extractor import CVSpacingExtractor
+from copy_that.application.openai_color_extractor import OpenAIColorExtractor
+from copy_that.application.spacing_extractor import AISpacingExtractor
+from copy_that.domain.models import (
+    ColorToken,
+    ExtractionJob,
+    Project,
+    ProjectSnapshot,
+    SpacingToken,
+)
+from copy_that.infrastructure.database import get_db
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/v1/extract", tags=["multi-extract"])
+
+
+class MultiExtractRequest(BaseModel):
+    image_base64: str = Field(..., description="Data URL or raw base64 image")
+    image_media_type: str | None = Field("image/png", description="Media type for image")
+    project_id: int | None = Field(None, description="Optional project to persist tokens")
+    token_types: Sequence[str] = Field(
+        default_factory=lambda: ["color", "spacing"],
+        description="List of token types to extract",
+    )
+    max_colors: int = 12
+    max_spacing_tokens: int = 20
+
+
+def _sanitize_numbers(obj):
+    """Recursively replace NaN/inf with None so JSON is valid."""
+    if isinstance(obj, float):
+        if not math.isfinite(obj):
+            return None
+        return obj
+    if isinstance(obj, dict):
+        return {k: _sanitize_numbers(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_sanitize_numbers(v) for v in obj]
+    return obj
+
+
+@router.post("/stream")
+async def extract_stream(request: MultiExtractRequest, db: AsyncSession = Depends(get_db)):
+    """Stream CV-first then AI refinement for requested token types."""
+
+    async def sse() -> AsyncGenerator[str, None]:
+        try:
+            # Validate project if provided
+            if request.project_id is not None:
+                res = await db.execute(select(Project).where(Project.id == request.project_id))
+                if not res.scalar_one_or_none():
+                    raise HTTPException(
+                        status_code=404, detail=f"Project {request.project_id} not found"
+                    )
+
+            def send(event: str, data: dict) -> str:
+                clean = _sanitize_numbers(data)
+                return f"event: {event}\ndata: {json.dumps(clean, allow_nan=False)}\n\n"
+
+            # CV color
+            cv_color_result = CVColorExtractor(max_colors=request.max_colors).extract_from_base64(
+                request.image_base64
+            )
+            yield send(
+                "token",
+                {
+                    "type": "color",
+                    "source": "cv",
+                    "tokens": [c.model_dump() for c in cv_color_result.colors],
+                },
+            )
+
+            # CV spacing
+            cv_spacing_result = CVSpacingExtractor(
+                max_tokens=request.max_spacing_tokens
+            ).extract_from_base64(request.image_base64)
+            yield send(
+                "token",
+                {
+                    "type": "spacing",
+                    "source": "cv",
+                    "tokens": [t.model_dump() for t in cv_spacing_result.tokens],
+                },
+            )
+
+            # AI refinement (parallel)
+            loop = asyncio.get_event_loop()
+            color_task = loop.run_in_executor(
+                None,
+                lambda: OpenAIColorExtractor().extract_colors_from_base64(
+                    request.image_base64,
+                    media_type=request.image_media_type or "image/png",
+                    max_colors=request.max_colors,
+                ),
+            )
+            spacing_task = loop.run_in_executor(
+                None,
+                lambda: AISpacingExtractor().extract_spacing_from_base64(
+                    request.image_base64.split(",")[1]
+                    if "," in request.image_base64
+                    else request.image_base64,
+                    request.image_media_type or "image/png",
+                    request.max_spacing_tokens,
+                ),
+            )
+
+            ai_color_result, ai_spacing_result = await asyncio.gather(color_task, spacing_task)
+
+            yield send(
+                "token",
+                {
+                    "type": "color",
+                    "source": "ai",
+                    "tokens": [c.model_dump() for c in ai_color_result.colors],
+                },
+            )
+            yield send(
+                "token",
+                {
+                    "type": "spacing",
+                    "source": "ai",
+                    "tokens": [t.model_dump() for t in ai_spacing_result.tokens],
+                },
+            )
+
+            # Persist if project_id provided
+            if request.project_id:
+                await _persist_color_tokens(db, request.project_id, ai_color_result.colors)
+                await _persist_spacing_tokens(db, request.project_id, ai_spacing_result.tokens)
+                await _persist_snapshot(
+                    db,
+                    request.project_id,
+                    ai_color_result.colors,
+                    ai_spacing_result.tokens,
+                    {
+                        "extractor": "openai+cv",
+                        "token_counts": {
+                            "colors": len(ai_color_result.colors),
+                            "spacing": len(ai_spacing_result.tokens),
+                        },
+                    },
+                )
+
+            yield send(
+                "complete",
+                {
+                    "status": "ok",
+                    "color_count": len(ai_color_result.colors),
+                    "spacing_count": len(ai_spacing_result.tokens),
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Multi-extract failed: %s", exc)
+            yield f"event: error\ndata: {json.dumps({'error': str(exc)})}\n\n"
+
+    return StreamingResponse(
+        sse(), media_type="text/event-stream", headers={"Cache-Control": "no-cache"}
+    )
+
+
+async def _persist_color_tokens(db: AsyncSession, project_id: int, tokens):
+    job = ExtractionJob(
+        project_id=project_id,
+        source_url="multi-extract",
+        extraction_type="color",
+        status="completed",
+        result_data=json.dumps({"color_count": len(tokens)}),
+    )
+    db.add(job)
+    await db.flush()
+    for c in tokens:
+        db.add(
+            ColorToken(
+                project_id=project_id,
+                extraction_job_id=job.id,
+                hex=c.hex,
+                rgb=c.rgb,
+                name=c.name,
+                design_intent=c.design_intent,
+                semantic_names=json.dumps(c.semantic_names) if c.semantic_names else None,
+                extraction_metadata=json.dumps(c.extraction_metadata)
+                if c.extraction_metadata
+                else None,
+                confidence=c.confidence,
+                harmony=c.harmony,
+                usage=json.dumps(c.usage) if c.usage else None,
+            )
+        )
+    await db.commit()
+
+
+async def _persist_spacing_tokens(db: AsyncSession, project_id: int, tokens):
+    job = ExtractionJob(
+        project_id=project_id,
+        source_url="multi-extract",
+        extraction_type="spacing",
+        status="completed",
+        result_data=json.dumps({"spacing_count": len(tokens)}),
+    )
+    db.add(job)
+    await db.flush()
+    for t in tokens:
+        db.add(
+            SpacingToken(
+                project_id=project_id,
+                extraction_job_id=job.id,
+                value_px=t.value_px,
+                name=t.name,
+                semantic_role=t.semantic_role,
+                spacing_type=t.spacing_type.value
+                if hasattr(t.spacing_type, "value")
+                else t.spacing_type,
+                category=t.category,
+                confidence=t.confidence,
+                usage=json.dumps(t.usage) if t.usage else None,
+            )
+        )
+    await db.commit()
+
+
+async def _persist_snapshot(
+    db: AsyncSession, project_id: int, colors: list, spacings: list, meta: dict | None = None
+):
+    """Persist an immutable snapshot blob for the project."""
+    payload = {
+        "colors": [c.model_dump() for c in colors],
+        "spacing": [t.model_dump() for t in spacings],
+        "meta": meta or {},
+    }
+    snapshot = ProjectSnapshot(
+        project_id=project_id,
+        version=1,  # could be incremented per project in future
+        data=json.dumps(_sanitize_numbers(payload)),
+    )
+    db.add(snapshot)
+    await db.commit()

--- a/src/copy_that/interfaces/api/projects.py
+++ b/src/copy_that/interfaces/api/projects.py
@@ -2,6 +2,9 @@
 Project Management Router
 """
 
+import json
+from typing import Any
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,6 +20,47 @@ from copy_that.interfaces.api.schemas import (
 router = APIRouter(prefix="/api/v1/projects", tags=["projects"])
 
 
+def _encode_description(
+    text: str | None,
+    image_base64: str | None,
+    image_media_type: str | None,
+    spacing_tokens: list[dict] | None = None,
+) -> str | None:
+    """Store text + image metadata as JSON in the description column."""
+    if not any([text, image_base64, image_media_type, spacing_tokens]):
+        return text
+    payload: dict[str, Any] = {}
+    if text:
+        payload["text"] = text
+    if image_base64:
+        payload["image_base64"] = image_base64
+    if image_media_type:
+        payload["image_media_type"] = image_media_type
+    if spacing_tokens:
+        payload["spacing_tokens"] = spacing_tokens
+    return json.dumps(payload)
+
+
+def _decode_description(
+    raw: str | None,
+) -> tuple[str | None, str | None, str | None, list[dict] | None]:
+    """Decode description JSON if present."""
+    if not raw:
+        return None, None, None, None
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return (
+                data.get("text"),
+                data.get("image_base64"),
+                data.get("image_media_type"),
+                data.get("spacing_tokens"),
+            )
+    except Exception:
+        return raw, None, None, None
+    return raw, None, None, None
+
+
 @router.post("", response_model=ProjectResponse, status_code=201)
 async def create_project(request: ProjectCreateRequest, db: AsyncSession = Depends(get_db)):
     """Create a new project
@@ -28,15 +72,22 @@ async def create_project(request: ProjectCreateRequest, db: AsyncSession = Depen
     Returns:
         Created project with ID
     """
-    project = Project(name=request.name, description=request.description)
+    description = _encode_description(
+        request.description, request.image_base64, request.image_media_type, request.spacing_tokens
+    )
+    project = Project(name=request.name, description=description)
     db.add(project)
     await db.commit()
     await db.refresh(project)
 
+    text, img_b64, img_type, spacing_tokens = _decode_description(project.description)
     return ProjectResponse(
         id=project.id,
         name=project.name,
-        description=project.description,
+        description=text,
+        image_base64=img_b64,
+        image_media_type=img_type,
+        spacing_tokens=spacing_tokens,
         created_at=project.created_at.isoformat(),
         updated_at=project.updated_at.isoformat(),
     )
@@ -65,16 +116,22 @@ async def list_projects(
     )
     projects = result.scalars().all()
 
-    return [
-        ProjectResponse(
-            id=p.id,
-            name=p.name,
-            description=p.description,
-            created_at=p.created_at.isoformat(),
-            updated_at=p.updated_at.isoformat(),
+    responses: list[ProjectResponse] = []
+    for p in projects:
+        text, img_b64, img_type, spacing_tokens = _decode_description(p.description)
+        responses.append(
+            ProjectResponse(
+                id=p.id,
+                name=p.name,
+                description=text,
+                image_base64=img_b64,
+                image_media_type=img_type,
+                spacing_tokens=spacing_tokens,
+                created_at=p.created_at.isoformat(),
+                updated_at=p.updated_at.isoformat(),
+            )
         )
-        for p in projects
-    ]
+    return responses
 
 
 @router.get("/{project_id}", response_model=ProjectResponse)
@@ -98,10 +155,14 @@ async def get_project(project_id: int, db: AsyncSession = Depends(get_db)):
             status_code=status.HTTP_404_NOT_FOUND, detail=f"Project {project_id} not found"
         )
 
+    text, img_b64, img_type, spacing_tokens = _decode_description(project.description)
     return ProjectResponse(
         id=project.id,
         name=project.name,
-        description=project.description,
+        description=text,
+        image_base64=img_b64,
+        image_media_type=img_type,
+        spacing_tokens=spacing_tokens,
         created_at=project.created_at.isoformat(),
         updated_at=project.updated_at.isoformat(),
     )
@@ -134,8 +195,17 @@ async def update_project(
     # Update fields if provided
     if request.name is not None:
         project.name = request.name
-    if request.description is not None:
-        project.description = request.description
+    # Merge description/image fields
+    current_text, current_img_b64, current_img_type, current_spacing = _decode_description(
+        project.description
+    )
+    new_text = request.description if request.description is not None else current_text
+    new_img_b64 = request.image_base64 if request.image_base64 is not None else current_img_b64
+    new_img_type = (
+        request.image_media_type if request.image_media_type is not None else current_img_type
+    )
+    new_spacing = request.spacing_tokens if request.spacing_tokens is not None else current_spacing
+    project.description = _encode_description(new_text, new_img_b64, new_img_type, new_spacing)
 
     project.updated_at = utc_now()
 
@@ -143,10 +213,14 @@ async def update_project(
     await db.commit()
     await db.refresh(project)
 
+    text, img_b64, img_type, spacing_tokens = _decode_description(project.description)
     return ProjectResponse(
         id=project.id,
         name=project.name,
-        description=project.description,
+        description=text,
+        image_base64=img_b64,
+        image_media_type=img_type,
+        spacing_tokens=spacing_tokens,
         created_at=project.created_at.isoformat(),
         updated_at=project.updated_at.isoformat(),
     )

--- a/src/copy_that/interfaces/api/projects.py
+++ b/src/copy_that/interfaces/api/projects.py
@@ -45,8 +45,10 @@ def _decode_description(
     raw: str | None,
 ) -> tuple[str | None, str | None, str | None, list[dict[str, Any]] | None]:
     """Decode description JSON if present."""
-    if not raw:
+    if raw is None:
         return None, None, None, None
+    if raw == "":
+        return "", None, None, None
     try:
         data: dict[str, Any] | str = json.loads(raw)
         if isinstance(data, dict):

--- a/src/copy_that/interfaces/api/projects.py
+++ b/src/copy_that/interfaces/api/projects.py
@@ -24,7 +24,7 @@ def _encode_description(
     text: str | None,
     image_base64: str | None,
     image_media_type: str | None,
-    spacing_tokens: list[dict] | None = None,
+    spacing_tokens: list[dict[str, Any]] | None = None,
 ) -> str | None:
     """Store text + image metadata as JSON in the description column."""
     if not any([text, image_base64, image_media_type, spacing_tokens]):
@@ -43,12 +43,12 @@ def _encode_description(
 
 def _decode_description(
     raw: str | None,
-) -> tuple[str | None, str | None, str | None, list[dict] | None]:
+) -> tuple[str | None, str | None, str | None, list[dict[str, Any]] | None]:
     """Decode description JSON if present."""
     if not raw:
         return None, None, None, None
     try:
-        data = json.loads(raw)
+        data: dict[str, Any] | str = json.loads(raw)
         if isinstance(data, dict):
             return (
                 data.get("text"),

--- a/src/copy_that/interfaces/api/schemas.py
+++ b/src/copy_that/interfaces/api/schemas.py
@@ -9,6 +9,15 @@ class ProjectCreateRequest(BaseModel):
 
     name: str = Field(..., min_length=1, max_length=255, description="Project name")
     description: str | None = Field(None, max_length=2000, description="Project description")
+    image_base64: str | None = Field(
+        None, description="Optional source image (base64 payload, no data URL prefix)"
+    )
+    image_media_type: str | None = Field(
+        None, description="Media type for source image (e.g., image/png)"
+    )
+    spacing_tokens: list[dict] | None = Field(
+        None, description="Optional spacing tokens to persist with the project"
+    )
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -18,6 +27,15 @@ class ProjectUpdateRequest(BaseModel):
 
     name: str | None = Field(None, min_length=1, max_length=255, description="Project name")
     description: str | None = Field(None, max_length=2000, description="Project description")
+    image_base64: str | None = Field(
+        None, description="Optional source image (base64 payload, no data URL prefix)"
+    )
+    image_media_type: str | None = Field(
+        None, description="Media type for source image (e.g., image/png)"
+    )
+    spacing_tokens: list[dict] | None = Field(
+        None, description="Optional spacing tokens to persist with the project"
+    )
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -28,6 +46,15 @@ class ProjectResponse(BaseModel):
     id: int = Field(..., description="Project ID")
     name: str = Field(..., description="Project name")
     description: str | None = Field(None, description="Project description")
+    image_base64: str | None = Field(
+        None, description="Source image (base64 payload, no data URL prefix)"
+    )
+    image_media_type: str | None = Field(
+        None, description="Media type for source image (e.g., image/png)"
+    )
+    spacing_tokens: list[dict] | None = Field(
+        None, description="Saved spacing tokens (if provided)"
+    )
     created_at: str = Field(..., description="Creation timestamp")
     updated_at: str = Field(..., description="Last update timestamp")
 
@@ -306,5 +333,23 @@ class ExportResponse(BaseModel):
     format: str = Field(..., description="Export format")
     content: str = Field(..., description="Exported content")
     mime_type: str = Field(..., description="MIME type of content")
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SpacingTokenDBResponse(BaseModel):
+    """DB-backed spacing token response."""
+
+    id: int
+    project_id: int
+    extraction_job_id: int | None = None
+    value_px: int
+    name: str
+    semantic_role: str | None = None
+    spacing_type: str | None = None
+    category: str | None = None
+    confidence: float
+    usage: list[str] | None = None
+    created_at: str
 
     model_config = ConfigDict(from_attributes=True)

--- a/src/copy_that/interfaces/api/snapshots.py
+++ b/src/copy_that/interfaces/api/snapshots.py
@@ -3,6 +3,7 @@ Project snapshots: list and fetch stored token snapshots.
 """
 
 import json
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
@@ -15,7 +16,9 @@ router = APIRouter(prefix="/api/v1/projects", tags=["snapshots"])
 
 
 @router.get("/{project_id}/snapshots")
-async def list_snapshots(project_id: int, db: AsyncSession = Depends(get_db)):
+async def list_snapshots(
+    project_id: int, db: AsyncSession = Depends(get_db)
+) -> list[dict[str, Any]]:
     """List snapshots for a project."""
     project = await db.scalar(select(Project).where(Project.id == project_id))
     if not project:
@@ -40,7 +43,9 @@ async def list_snapshots(project_id: int, db: AsyncSession = Depends(get_db)):
 
 
 @router.get("/{project_id}/snapshots/{snapshot_id}")
-async def get_snapshot(project_id: int, snapshot_id: int, db: AsyncSession = Depends(get_db)):
+async def get_snapshot(
+    project_id: int, snapshot_id: int, db: AsyncSession = Depends(get_db)
+) -> dict[str, Any]:
     """Fetch a snapshot payload."""
     snap = await db.scalar(
         select(ProjectSnapshot).where(

--- a/src/copy_that/interfaces/api/snapshots.py
+++ b/src/copy_that/interfaces/api/snapshots.py
@@ -1,0 +1,65 @@
+"""
+Project snapshots: list and fetch stored token snapshots.
+"""
+
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from copy_that.domain.models import Project, ProjectSnapshot
+from copy_that.infrastructure.database import get_db
+
+router = APIRouter(prefix="/api/v1/projects", tags=["snapshots"])
+
+
+@router.get("/{project_id}/snapshots")
+async def list_snapshots(project_id: int, db: AsyncSession = Depends(get_db)):
+    """List snapshots for a project."""
+    project = await db.scalar(select(Project).where(Project.id == project_id))
+    if not project:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"Project {project_id} not found"
+        )
+    result = await db.execute(
+        select(ProjectSnapshot)
+        .where(ProjectSnapshot.project_id == project_id)
+        .order_by(ProjectSnapshot.created_at.desc())
+    )
+    snaps = result.scalars().all()
+    return [
+        {
+            "id": s.id,
+            "project_id": s.project_id,
+            "version": s.version,
+            "created_at": s.created_at.isoformat(),
+        }
+        for s in snaps
+    ]
+
+
+@router.get("/{project_id}/snapshots/{snapshot_id}")
+async def get_snapshot(project_id: int, snapshot_id: int, db: AsyncSession = Depends(get_db)):
+    """Fetch a snapshot payload."""
+    snap = await db.scalar(
+        select(ProjectSnapshot).where(
+            ProjectSnapshot.id == snapshot_id, ProjectSnapshot.project_id == project_id
+        )
+    )
+    if not snap:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Snapshot {snapshot_id} not found for project {project_id}",
+        )
+    try:
+        data = json.loads(snap.data)
+    except Exception:
+        data = snap.data
+    return {
+        "id": snap.id,
+        "project_id": snap.project_id,
+        "version": snap.version,
+        "created_at": snap.created_at.isoformat(),
+        "data": data,
+    }

--- a/tests/ui/test_color_extraction.py
+++ b/tests/ui/test_color_extraction.py
@@ -84,9 +84,7 @@ class TestColorDisplay:
         """Test that color cards display all required attributes"""
         # Inject test data via JavaScript
         page.goto("http://localhost:8000/")
-        page.evaluate(f"""
-            showResults({mock_colors_response});
-        """)
+        page.evaluate("(data) => showResults(data)", mock_colors_response)
 
         # Check that color cards are created
         color_cards = page.locator(".color-card")
@@ -130,9 +128,7 @@ class TestColorDisplay:
     def test_extractor_used_displayed_in_stats(self, page: Page, mock_colors_response):
         """Test that the AI model used is displayed in stats"""
         page.goto("http://localhost:8000/")
-        page.evaluate(f"""
-            showResults({mock_colors_response});
-        """)
+        page.evaluate("(data) => showResults(data)", mock_colors_response)
 
         stats = page.locator("#stats")
         expect(stats).to_contain_text("gpt-4o")
@@ -141,9 +137,7 @@ class TestColorDisplay:
     def test_color_count_displayed(self, page: Page, mock_colors_response):
         """Test that color count is displayed correctly"""
         page.goto("http://localhost:8000/")
-        page.evaluate(f"""
-            showResults({mock_colors_response});
-        """)
+        page.evaluate("(data) => showResults(data)", mock_colors_response)
 
         stats = page.locator("#stats")
         expect(stats).to_contain_text("2")

--- a/tests/unit/pipeline/generator/test_cli_figma.py
+++ b/tests/unit/pipeline/generator/test_cli_figma.py
@@ -1,0 +1,34 @@
+"""Tests for generate_figma_tokens CLI helper."""
+
+from pathlib import Path
+
+from scripts.generate_figma_tokens import generate_figma
+
+
+def test_generate_figma(tmp_path: Path):
+    """Ensure figma output is produced from simple token JSON."""
+    input_path = tmp_path / "tokens.json"
+    output_path = tmp_path / "figma.json"
+    input_path.write_text(
+        """
+        {
+          "tokens": [
+            {
+              "name": "primary",
+              "path": ["color", "brand"],
+              "token_type": "color",
+              "w3c_type": "color",
+              "value": "#FF6B35",
+              "confidence": 0.95,
+              "description": "Primary brand color"
+            }
+          ]
+        }
+        """
+    )
+
+    generate_figma(input_path, output_path)
+
+    content = output_path.read_text()
+    assert '"version": "1.0"' in content
+    assert '"collections"' in content


### PR DESCRIPTION
**Summary**

- add SSE multi-extract endpoint (CV-first + OpenAI) for colors and spacing; persist tokens and project snapshots
- introduce spacing_tokens and project_snapshots migrations; expose snapshot list/fetch API and batch color/spacing endpoints
- enhance frontend root page with SSE streaming, snapshot load, richer token metadata, and spacing CV fast-path visualization
- update docs/README/CHANGELOG and architecture parity notes

**Tests**

- pre-commit run --all-files (ruff, formatting, mypy, pytest-fast)