### PR TITLE
chore/unify-cv-preprocess

### DIFF
--- a/src/copy_that/application/cv/color_cv_extractor.py
+++ b/src/copy_that/application/cv/color_cv_extractor.py
@@ -6,7 +6,6 @@ Goal: fast local palette for immediate UI render, later refined by AI.
 
 from __future__ import annotations
 
-import io
 from collections import Counter
 from collections import Counter as CounterType
 from typing import Any, cast
@@ -17,6 +16,7 @@ from PIL import Image
 from copy_that.application.color_extractor import ColorExtractionResult, ExtractedColorToken
 from core.tokens.color import make_color_token
 from core.tokens.repository import TokenRepository
+from cv_pipeline.preprocess import preprocess_image
 
 
 class CVColorExtractor:
@@ -32,7 +32,8 @@ class CVColorExtractor:
         token_repo: TokenRepository | None = None,
         token_namespace: str = "token/color/cv",
     ) -> ColorExtractionResult:
-        image = Image.open(io.BytesIO(data)).convert("RGB")
+        views = preprocess_image(data)
+        image = views["pil_image"]
         # Quantize to palette for speed
         image_module = cast(Any, Image)
         palette_arg: Any = getattr(image_module, "ADAPTIVE", None)

--- a/tests/application/cv/test_spacing_cv_preprocess_integration.py
+++ b/tests/application/cv/test_spacing_cv_preprocess_integration.py
@@ -1,0 +1,31 @@
+"""Integration test ensuring spacing CV extractor uses shared preprocessing."""
+
+from __future__ import annotations
+
+import io
+
+from PIL import Image, ImageDraw
+
+from copy_that.application.cv.spacing_cv_extractor import CVSpacingExtractor
+
+
+def _synthetic_spacing_image() -> bytes:
+    """Create a simple image with two black rectangles to force detectable gaps."""
+    img = Image.new("RGB", (200, 200), "white")
+    draw = ImageDraw.Draw(img)
+    draw.rectangle((10, 50, 40, 150), fill="black")
+    draw.rectangle((100, 50, 130, 150), fill="black")
+    buffer = io.BytesIO()
+    img.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def test_spacing_cv_extractor_uses_preprocess_and_returns_tokens() -> None:
+    data = _synthetic_spacing_image()
+    extractor = CVSpacingExtractor(max_tokens=5)
+    result = extractor.extract_from_bytes(data)
+
+    assert result.tokens, "Expected spacing tokens from CV extractor"
+    assert result.base_unit in (4, 8)
+    # Ensure we produced at least one grid-aligned token
+    assert any(t.grid_aligned for t in result.tokens if hasattr(t, "grid_aligned"))


### PR DESCRIPTION
**Summary:**

- Add design_tokens (W3C JSON via TokenRepository + adapter) to color/spacing extraction responses; streaming includes the export.
- New /api/v1/colors/export/w3c and /api/v1/spacing/export/w3c routes for direct W3C output.
- Introduced make_spacing_token helper and updated schema tests to cover the new field.