### PR TITLE
Bootstrap test DB and fix color library stats 

### DIFF
--- a/docs/architecture/backend_architecture.md
+++ b/docs/architecture/backend_architecture.md
@@ -7,7 +7,7 @@ This backend follows a service-layered FastAPI stack with a shared token graph c
 ```mermaid
 flowchart TD
     client["Client UI/CLI"] --> api["FastAPI Router"]
-    api --> services["Service Layer (colors_service, spacing_service)"]
+    api --> services["Service Layer (colors_service, spacing_service, projects_service, sessions_service)"]
     services --> app["Application Logic (extractors, CV, AI clients)"]
     services --> tokens["Token Graph (core/tokens/*)"]
     tokens --> adapters["Adapters (W3C/custom)"]
@@ -21,6 +21,8 @@ flowchart TD
 - **Service layer (`src/copy_that/services/`)**: Small helpers that normalize inputs/outputs, build token repositories, serialize DB models, and wrap exports. Current services:
   - `colors_service.py`: repo builders, serialization, W3C export response for colors.
   - `spacing_service.py`: repo builders, CV/AI merge and batch aggregation for spacing.
+  - `projects_service.py`: get/create project helpers for routers.
+  - `sessions_service.py`: get/create session and token library helpers.
 - **Token graph (`core/tokens/*`)**: `Token` model, repositories, adapters (W3C), aggregation helpers (`aggregate.py`).
 - **Application extractors (`src/copy_that/application/`, `cv_pipeline/`)**: CV and AI extractors for colors/spacing; remain focused on extraction logic.
 - **Infrastructure**: Postgres/Redis via docker-compose for local dev; `infrastructure/database.py` for DB sessions.

--- a/src/copy_that/generators/library_models.py
+++ b/src/copy_that/generators/library_models.py
@@ -41,11 +41,31 @@ class TokenLibrary:
 
     def add_token(self, token: AggregatedColorToken) -> None:
         self.tokens.append(token)
+        self.compute_statistics()
 
     @property
     def stats(self) -> dict:
         """Backward-compatible accessor used by legacy tests."""
         return self.statistics
+
+    def compute_statistics(self) -> None:
+        """Compute simple library statistics used by legacy generators/tests."""
+        if not self.tokens:
+            self.statistics = {}
+            return
+
+        confidences = [
+            token.confidence
+            for token in self.tokens
+            if getattr(token, "confidence", None) is not None
+        ]
+
+        self.statistics = {
+            "color_count": len(self.tokens),
+            "avg_confidence": sum(confidences) / len(confidences) if confidences else 0,
+            "min_confidence": min(confidences) if confidences else 0,
+            "max_confidence": max(confidences) if confidences else 0,
+        }
 
     def to_dict(self) -> dict:
         return {

--- a/src/copy_that/generators/library_models.py
+++ b/src/copy_that/generators/library_models.py
@@ -39,6 +39,14 @@ class TokenLibrary:
     statistics: dict = field(default_factory=dict)
     token_type: str = "color"
 
+    def add_token(self, token: AggregatedColorToken) -> None:
+        self.tokens.append(token)
+
+    @property
+    def stats(self) -> dict:
+        """Backward-compatible accessor used by legacy tests."""
+        return self.statistics
+
     def to_dict(self) -> dict:
         return {
             "tokens": [vars(t) for t in self.tokens],

--- a/src/copy_that/services/colors_service.py
+++ b/src/copy_that/services/colors_service.py
@@ -85,7 +85,8 @@ def db_colors_to_repo(colors: Sequence[Any], namespace: str) -> TokenRepository:
             "delta_e_to_dominant": getattr(color, "delta_e_to_dominant", None),
             "is_neutral": getattr(color, "is_neutral", None),
         }
-        repo.upsert_token(make_color_token(f"{namespace}/{index:02d}", Color(attrs["hex"]), attrs))
+        hex_value = attrs.get("hex") or "#000000"
+        repo.upsert_token(make_color_token(f"{namespace}/{index:02d}", Color(hex_value), attrs))
     return repo
 
 

--- a/tests/utils/test_db.py
+++ b/tests/utils/test_db.py
@@ -1,0 +1,70 @@
+"""Helpers to bootstrap a test database (Postgres or in-memory) with minimal seed data."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.pool import NullPool, StaticPool
+
+from copy_that.domain.models import Base, ExtractionSession, Project, TokenLibrary
+
+
+async def create_engine_from_env() -> AsyncEngine:
+    """Create an async engine from TEST_DATABASE_URL or use in-memory SQLite."""
+    db_url = os.getenv("TEST_DATABASE_URL")
+    if db_url:
+        return create_async_engine(db_url, poolclass=NullPool, echo=False)
+    # default to in-memory sqlite
+    return create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+        echo=False,
+    )
+
+
+async def prepare_db(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    """Create all tables and return a sessionmaker."""
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+async def seed_minimal(session: AsyncSession) -> None:
+    """Seed minimal data required by API tests."""
+    project = Project(name="Test Project", description="Seeded project for API tests")
+    project2 = Project(name="Another Project", description="Second seeded project")
+    session.add_all([project, project2])
+    await session.commit()
+    await session.refresh(project)
+    await session.refresh(project2)
+
+    session_obj = ExtractionSession(
+        project_id=project.id,
+        name="Default Session",
+        description="Seeded session for API tests",
+    )
+    session.add(session_obj)
+    await session.flush()
+    library = TokenLibrary(session_id=session_obj.id, token_type="color", statistics=None)
+    session.add(library)
+    await session.commit()
+    await session.refresh(session_obj)
+    await session.refresh(library)
+
+
+async def get_test_session() -> AsyncGenerator[AsyncSession, None]:
+    """Context manager-ish helper to yield a seeded session and clean up."""
+    engine = await create_engine_from_env()
+    SessionLocal = await prepare_db(engine)
+    async with SessionLocal() as session:
+        await seed_minimal(session)
+        yield session
+    await engine.dispose()


### PR DESCRIPTION
Summary

- Rebase test bootstrap on main, 
- seed minimal data via shared fixture helpers, and 
- add stats computation to TokenLibrary so color generator e2e tests pass. 
- Tested in Docker with TEST_DATABASE_URL and color pipeline e2e cases.