### PR TITLE
chore: centralize spacing CV primitives

### DIFF
--- a/src/cv_pipeline/primitives.py
+++ b/src/cv_pipeline/primitives.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 import cv2
@@ -69,3 +70,60 @@ def detect_lines(gray: NDArray[np.uint8]) -> list[Line]:
         for x1, y1, x2, y2 in segments[:, 0]:
             lines.append(Line(start=(int(x1), int(y1)), end=(int(x2), int(y2))))
     return lines
+
+
+def bounding_boxes_from_contours(
+    gray: NDArray[np.uint8],
+    *,
+    canny_threshold1: int = 50,
+    canny_threshold2: int = 150,
+    min_area: int = 16,
+) -> list[tuple[int, int, int, int]]:
+    """
+    Extract axis-aligned bounding boxes from contours on a grayscale image.
+
+    Returns a list of (x, y, w, h) tuples.
+    """
+    edges = cv2.Canny(gray, canny_threshold1, canny_threshold2)
+    contours, _ = cv2.findContours(edges, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
+    boxes: list[tuple[int, int, int, int]] = []
+    for contour in contours:
+        x, y, w, h = cv2.boundingRect(contour)
+        if w * h >= min_area:
+            boxes.append((int(x), int(y), int(w), int(h)))
+    return boxes
+
+
+def measure_spacing_gaps(
+    bboxes: Iterable[tuple[int, int, int, int]],
+    *,
+    min_gap: int = 2,
+    max_gap: int = 200,
+) -> tuple[list[int], list[int]]:
+    """
+    Compute horizontal and vertical gaps between sorted bounding boxes.
+
+    Returns (x_gaps, y_gaps) in pixels.
+    """
+    x_gaps: list[int] = []
+    y_gaps: list[int] = []
+    sorted_x = sorted(bboxes, key=lambda b: b[0])
+    sorted_y = sorted(bboxes, key=lambda b: b[1])
+
+    for i in range(len(sorted_x) - 1):
+        _, _, w1, _ = sorted_x[i]
+        x1 = sorted_x[i][0] + w1
+        x2 = sorted_x[i + 1][0]
+        gap = x2 - x1
+        if min_gap <= gap <= max_gap:
+            x_gaps.append(gap)
+
+    for i in range(len(sorted_y) - 1):
+        _, _, _, h1 = sorted_y[i]
+        y1 = sorted_y[i][1] + h1
+        y2 = sorted_y[i + 1][1]
+        gap = y2 - y1
+        if min_gap <= gap <= max_gap:
+            y_gaps.append(gap)
+
+    return x_gaps, y_gaps

--- a/tests/application/cv/test_spacing_cv_preprocess_integration.py
+++ b/tests/application/cv/test_spacing_cv_preprocess_integration.py
@@ -29,3 +29,21 @@ def test_spacing_cv_extractor_uses_preprocess_and_returns_tokens() -> None:
     assert result.base_unit in (4, 8)
     # Ensure we produced at least one grid-aligned token
     assert any(t.grid_aligned for t in result.tokens if hasattr(t, "grid_aligned"))
+
+
+def test_spacing_cv_extractor_gap_regression() -> None:
+    """
+    Regression: ensure shared primitives produce stable spacing gaps.
+    """
+    data = _synthetic_spacing_image()
+    extractor = CVSpacingExtractor(max_tokens=5)
+    result = extractor.extract_from_bytes(data)
+
+    assert result.tokens
+    assert len(result.unique_values) == 1
+    gap = result.unique_values[0]
+    # Allow minor variance from contour detection but keep expected quantization and scale.
+    assert 40 <= gap <= 80
+    assert gap % 4 == 0
+    assert result.base_unit in (4, 8)
+    assert result.tokens[0].value_px == gap


### PR DESCRIPTION
**Summary**:

- Add shared bbox/gap helpers in cv_pipeline.primitives.
- Refactor CVSpacingExtractor to use shared preprocessing and primitives.
- Add regression test to keep spacing CV output stable on a synthetic image.
- Tests: pytest tests/application/cv/test_spacing_cv_preprocess_integration.py -q (plus pre-push hooks incl. mypy and fast unit tests).