### PR TITLE
feat/frontend-upload

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -98,6 +98,42 @@
   gap: var(--space-lg);
 }
 
+.app-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: var(--space-lg);
+  align-items: start;
+}
+
+.panel {
+  background: var(--color-surface, #fff);
+  border: 1px solid var(--color-neutral-100);
+  border-radius: 12px;
+  padding: var(--space-lg);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.04);
+}
+
+.panel h2 {
+  margin: 0 0 var(--space-xs) 0;
+  font-size: var(--font-size-lg);
+  color: var(--color-text-primary);
+}
+
+.panel-subtitle {
+  margin: 0 0 var(--space-md) 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.loading-chip {
+  background: var(--color-neutral-50);
+  color: var(--color-text-secondary);
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: 999px;
+  font-size: var(--font-size-sm);
+  border: 1px solid var(--color-neutral-100);
+}
+
 /* Layout overrides to keep token grid visible without excessive height */
 .color-tokens.layout-new {
   height: auto !important;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
 import './App.css'
-import AdvancedColorScienceDemo from './components/AdvancedColorScienceDemo'
-import SpacingTokenShowcase from './components/SpacingTokenShowcase'
+import ImageUploader from './components/ImageUploader'
+import ColorTokenDisplay from './components/ColorTokenDisplay'
+import type { ColorToken } from './types'
 
 export default function App() {
   // Ensure global scroll isn’t disabled by other styles
@@ -16,5 +17,89 @@ export default function App() {
     }
   }, [])
 
-  return <AdvancedColorScienceDemo />
+  const [projectId, setProjectId] = useState<number | null>(null)
+  const [colors, setColors] = useState<ColorToken[]>([])
+  const [error, setError] = useState<string>('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [hasUpload, setHasUpload] = useState(false)
+
+  const handleColorsExtracted = (extracted: ColorToken[]) => {
+    setColors(extracted)
+    setHasUpload(true)
+  }
+
+  const handleProjectCreated = (id: number) => {
+    setProjectId(id)
+  }
+
+  const handleError = (message: string) => {
+    setError(message)
+  }
+
+  const handleLoadingChange = (loading: boolean) => {
+    setIsLoading(loading)
+  }
+
+  return (
+    <div className="app">
+      <header className="app-header">
+        <div className="header-content">
+          <div className="header-title">
+            <h1>Copy That Playground</h1>
+            {projectId != null && <span className="project-id">Project #{projectId}</span>}
+          </div>
+          {isLoading && (
+            <div className="loading-chip" aria-live="polite">
+              Processing image…
+            </div>
+          )}
+        </div>
+        {error && <div className="error-banner">{error}</div>}
+      </header>
+
+      <main className="app-main">
+        <div className="app-grid">
+          <section className="panel">
+            <h2>Upload an image</h2>
+            <p className="panel-subtitle">
+              We’ll send it to the backend, stream the extraction, and render tokens below.
+            </p>
+            <ImageUploader
+              projectId={projectId}
+              onProjectCreated={handleProjectCreated}
+              onColorExtracted={handleColorsExtracted}
+              onError={handleError}
+              onLoadingChange={handleLoadingChange}
+            />
+          </section>
+
+          <section className="panel">
+            <h2>Extracted tokens</h2>
+            <p className="panel-subtitle">
+              Browse the palette and details as soon as extraction completes.
+            </p>
+            {hasUpload && colors.length === 0 && !isLoading && (
+              <div className="empty-state">
+                <div className="empty-content">
+                  <div className="empty-icon">⌛</div>
+                  <p className="empty-title">No tokens yet</p>
+                  <p className="empty-subtitle">Upload an image to see extracted colors</p>
+                </div>
+              </div>
+            )}
+            {colors.length > 0 && <ColorTokenDisplay colors={colors} />}
+            {!hasUpload && colors.length === 0 && (
+              <div className="empty-state">
+                <div className="empty-content">
+                  <div className="empty-icon">🖼️</div>
+                  <p className="empty-title">Drop an image to begin</p>
+                  <p className="empty-subtitle">We’ll stream results from the backend</p>
+                </div>
+              </div>
+            )}
+          </section>
+        </div>
+      </main>
+    </div>
+  )
 }

--- a/src/core/tokens/adapters/w3c.py
+++ b/src/core/tokens/adapters/w3c.py
@@ -13,6 +13,7 @@ def tokens_to_w3c(repo: TokenRepository) -> dict[str, Any]:
     payload: dict[str, Any] = {}
     sections = [
         ("color", repo.find_by_type("color"), _token_to_w3c_color_entry),
+        ("spacing", repo.find_by_type("spacing"), _token_to_w3c_spacing_entry),
         ("shadow", repo.find_by_type("shadow"), _token_to_w3c_shadow_entry),
         ("typography", repo.find_by_type("typography"), _token_to_w3c_typography_entry),
     ]
@@ -27,6 +28,8 @@ def w3c_to_tokens(data: dict[str, Any], repo: TokenRepository) -> None:
     """Load tokens from W3C Design Tokens JSON into the repository."""
     for token_id, entry in data.get("color", {}).items():
         repo.upsert_token(_w3c_color_entry_to_token(token_id, entry))
+    for token_id, entry in data.get("spacing", {}).items():
+        repo.upsert_token(_w3c_spacing_entry_to_token(token_id, entry))
     for token_id, entry in data.get("shadow", {}).items():
         repo.upsert_token(_w3c_shadow_entry_to_token(token_id, entry))
     for token_id, entry in data.get("typography", {}).items():
@@ -43,6 +46,30 @@ def _w3c_color_entry_to_token(token_id: str, entry: dict[str, Any]) -> Token:
     value = entry.get("value")
     attributes = {k: v for k, v in entry.items() if k not in {"value", "$type"}}
     return Token(id=token_id, type="color", value=value, attributes=attributes)
+
+
+def _token_to_w3c_spacing_entry(token: Token) -> dict[str, Any]:
+    value = token.value or {}
+    px = value.get("px") if isinstance(value, dict) else None
+    rem = value.get("rem") if isinstance(value, dict) else None
+    entry = {"value": f"{px}px" if px is not None else value, "$type": "dimension"}
+    if rem is not None:
+        entry["rem"] = rem
+    entry.update(token.attributes)
+    return entry
+
+
+def _w3c_spacing_entry_to_token(token_id: str, entry: dict[str, Any]) -> Token:
+    raw_value = entry.get("value")
+    px = None
+    if isinstance(raw_value, str) and raw_value.endswith("px"):
+        try:
+            px = float(raw_value[:-2])
+        except ValueError:
+            px = None
+    attributes = {k: v for k, v in entry.items() if k not in {"value", "$type"}}
+    value = {"px": px, "rem": attributes.pop("rem", None)}
+    return Token(id=token_id, type="spacing", value=value, attributes=attributes)
 
 
 def _token_to_w3c_shadow_entry(token: Token) -> dict[str, Any]:

--- a/tests/unit/api/test_w3c_export_contracts.py
+++ b/tests/unit/api/test_w3c_export_contracts.py
@@ -1,0 +1,130 @@
+"""Contract tests for W3C export endpoints and design_tokens payloads."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from copy_that.application.color_extractor import ColorExtractionResult, ExtractedColorToken
+from copy_that.domain.models import Base, ColorToken, Project, SpacingToken
+from copy_that.infrastructure.database import get_db
+from copy_that.interfaces.api.main import app
+from copy_that.services.colors_service import result_to_response
+
+
+@pytest_asyncio.fixture
+async def async_db():
+    """Create an in-memory SQLite database for API contract tests."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        echo=False,
+    )
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async with AsyncSession(engine, expire_on_commit=False) as session:
+        yield session
+
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(async_db):
+    """ASGI test client backed by the in-memory DB."""
+
+    async def override_get_db():
+        yield async_db
+
+    app.dependency_overrides[get_db] = override_get_db
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+@pytest_asyncio.fixture
+async def project(async_db):
+    """Seed a project for token association."""
+    p = Project(name="W3C Export Project", description="For W3C export contract tests")
+    async_db.add(p)
+    await async_db.commit()
+    await async_db.refresh(p)
+    return p
+
+
+@pytest.mark.asyncio
+async def test_export_colors_w3c_shape(client, async_db, project):
+    """Ensure /colors/export/w3c returns W3C-shaped color tokens."""
+    color = ColorToken(
+        project_id=project.id,
+        hex="#112233",
+        rgb="rgb(17, 34, 51)",
+        name="Primary",
+        confidence=0.9,
+    )
+    async_db.add(color)
+    await async_db.commit()
+
+    resp = await client.get("/api/v1/colors/export/w3c", params={"project_id": project.id})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "color" in data
+    entry = next(iter(data["color"].values()))
+    assert entry["$type"] == "color"
+    assert entry["value"]["space"] == "oklch"
+    assert {"l", "c", "h"} <= set(entry["value"].keys())
+
+
+@pytest.mark.asyncio
+async def test_export_spacing_w3c_shape(client, async_db, project):
+    """Ensure /spacing/export/w3c returns W3C-shaped spacing tokens."""
+    spacing = SpacingToken(
+        project_id=project.id,
+        value_px=8,
+        name="spacing-xxs",
+        semantic_role="layout",
+        category="cv",
+        confidence=0.8,
+    )
+    async_db.add(spacing)
+    await async_db.commit()
+
+    resp = await client.get("/api/v1/spacing/export/w3c", params={"project_id": project.id})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "spacing" in data
+    entry = next(iter(data["spacing"].values()))
+    assert entry["$type"] == "dimension"
+    assert isinstance(entry["value"], str)
+    assert entry["value"].endswith("px")
+    assert entry.get("rem") == pytest.approx(0.5)
+
+
+def test_design_tokens_present_in_color_response():
+    """Ensure service response carries design_tokens derived from repo."""
+    token = ExtractedColorToken(
+        hex="#445566",
+        rgb="rgb(68, 85, 102)",
+        name="Accent",
+        confidence=0.7,
+        usage=[],
+    )
+    result = ColorExtractionResult(
+        colors=[token],
+        dominant_colors=["#445566"],
+        color_palette="test",
+        extraction_confidence=0.7,
+        extractor_used="test",
+    )
+
+    payload = result_to_response(result, namespace="token/color/test")
+    assert "design_tokens" in payload
+    dt = payload["design_tokens"]
+    assert "color" in dt
+    entry = next(iter(dt["color"].values()))
+    assert entry["$type"] == "color"


### PR DESCRIPTION
**Summary:**

- Wire the App to use ImageUploader and ColorTokenDisplay so users can upload images, stream extraction through the backend, and browse returned tokens.
- Add app-level project/loader/error state and empty/loading panels; update layout styling for the new upload/results panels.
- Hooks/mypy/fast unit checks ran on push; verify in dev with pnpm dev (proxy to :8000).