### PR TITLE
Feat/oklch-clustering → Add spacing confidence metadata and color feature badges

### DIFF
--- a/frontend/src/components/ColorDetailPanel.css
+++ b/frontend/src/components/ColorDetailPanel.css
@@ -82,6 +82,22 @@
   word-break: break-word;
 }
 
+.background-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.6rem;
+  height: 22px;
+  margin-bottom: 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #0f172a;
+  background: #f7fee7;
+  border-radius: 999px;
+  border: 1px solid rgba(16, 185, 129, 0.3);
+  text-transform: uppercase;
+  letter-spacing: 0.25px;
+}
+
 .merge-badge {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/components/ColorDetailPanel.css
+++ b/frontend/src/components/ColorDetailPanel.css
@@ -82,6 +82,22 @@
   word-break: break-word;
 }
 
+.merge-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.25rem;
+  padding: 0 0.65rem;
+  height: 24px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #fde047;
+  background: rgba(79, 70, 229, 0.12);
+  border-radius: 999px;
+  border: 1px solid rgba(249, 250, 251, 0.4);
+  letter-spacing: 0.3px;
+}
+
 .hex-clickable {
   display: inline-block;
   font-size: 1.1rem;

--- a/frontend/src/components/ColorDetailPanel.tsx
+++ b/frontend/src/components/ColorDetailPanel.tsx
@@ -39,6 +39,11 @@ export function ColorDetailPanel({ color }: Props) {
             />
             <div className="header-info">
               <h2 className="color-name">{color.name}</h2>
+              {color.background_role && (
+                <span className={`background-badge ${color.background_role}`}>
+                  {color.background_role} background
+                </span>
+              )}
               {color.count != null && color.count > 1 && (
                 <span className="merge-badge">OKLCH merged</span>
               )}

--- a/frontend/src/components/ColorDetailPanel.tsx
+++ b/frontend/src/components/ColorDetailPanel.tsx
@@ -39,6 +39,9 @@ export function ColorDetailPanel({ color }: Props) {
             />
             <div className="header-info">
               <h2 className="color-name">{color.name}</h2>
+              {color.count != null && color.count > 1 && (
+                <span className="merge-badge">OKLCH merged</span>
+              )}
               <code
                 className="hex-clickable"
                 onClick={() => void copyToClipboard(color.hex)}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -76,6 +76,7 @@ export interface ColorToken {
   library_id?: number;
   role?: string;  // 'primary', 'secondary', 'accent', 'neutral', etc.
   provenance?: Record<string, number>;  // {"image_1": 0.95, "image_2": 0.88}
+  background_role?: string; // primary/secondary background indicator
 }
 
 /**

--- a/src/copy_that/application/color_extractor.py
+++ b/src/copy_that/application/color_extractor.py
@@ -96,6 +96,9 @@ class ExtractedColorToken(BaseModel):
         None, description="Delta E distance to nearest dominant color"
     )
     is_neutral: bool | None = Field(None, description="Is this a neutral/grayscale color")
+    background_role: str | None = Field(
+        None, description="Background role suggestion (primary/secondary)"
+    )
 
     # ML/CV Model Properties (for educational pipeline)
     kmeans_cluster_id: int | None = Field(None, description="K-means cluster assignment")
@@ -126,6 +129,10 @@ class ColorExtractionResult(BaseModel):
         ..., ge=0, le=1, description="Overall extraction confidence"
     )
     extractor_used: str = Field("", description="AI model used for extraction")
+    background_colors: list[str] = Field(
+        default_factory=list,
+        description="Identified background color hex codes (primary/secondary)",
+    )
 
 
 class AIColorExtractor:
@@ -421,6 +428,7 @@ Important: Every color MUST have a semantic token name. Be specific and consiste
             ]
             dominant_colors = ["#FF6B6B", "#4ECDC4", "#45B7D1"]
 
+        background_colors = color_utils.assign_background_roles(colors)
         return ColorExtractionResult(
             colors=colors[:max_colors],
             dominant_colors=dominant_colors[:3],
@@ -428,6 +436,7 @@ Important: Every color MUST have a semantic token name. Be specific and consiste
             extraction_confidence=sum(c.confidence for c in colors) / len(colors)
             if colors
             else 0.5,
+            background_colors=background_colors,
         )
 
     @staticmethod

--- a/src/copy_that/application/tests/test_delta_e_merging.py
+++ b/src/copy_that/application/tests/test_delta_e_merging.py
@@ -44,7 +44,7 @@ class TestColorMerging:
         from copy_that.application.color_utils import merge_similar_colors
 
         colors = ["#FF0000", "#FF0001", "#FF0002"]  # Very similar reds
-        result = merge_similar_colors(colors, threshold=1.0)
+        result = merge_similar_colors(colors, threshold=2.0)
 
         # Should merge nearly identical colors
         assert len(result) <= len(colors)
@@ -55,7 +55,7 @@ class TestColorMerging:
         from copy_that.application.color_utils import merge_similar_colors
 
         colors = ["#FF0000", "#0000FF"]  # Very different colors
-        result = merge_similar_colors(colors, threshold=15.0)
+        result = merge_similar_colors(colors, threshold=5.0)
 
         # Should keep both colors as they're different
         assert len(result) == 2
@@ -66,8 +66,8 @@ class TestColorMerging:
 
         colors = ["#FF0000", "#FF1111", "#0000FF"]
 
-        result_strict = merge_similar_colors(colors, threshold=5.0)
-        result_loose = merge_similar_colors(colors, threshold=30.0)
+        result_strict = merge_similar_colors(colors, threshold=1.0)
+        result_loose = merge_similar_colors(colors, threshold=4.0)
 
         # Stricter threshold should result in more colors
         assert len(result_strict) >= len(result_loose)
@@ -76,7 +76,7 @@ class TestColorMerging:
         """RED: Should handle empty color list."""
         from copy_that.application.color_utils import merge_similar_colors
 
-        result = merge_similar_colors([], threshold=15.0)
+        result = merge_similar_colors([], threshold=2.0)
         assert result == []
 
     def test_merge_similar_colors_single_color(self):
@@ -84,7 +84,7 @@ class TestColorMerging:
         from copy_that.application.color_utils import merge_similar_colors
 
         colors = ["#FF0000"]
-        result = merge_similar_colors(colors, threshold=15.0)
+        result = merge_similar_colors(colors, threshold=2.0)
 
         assert len(result) == 1
         assert result[0] == "#FF0000"
@@ -94,12 +94,21 @@ class TestColorMerging:
         from copy_that.application.color_utils import merge_similar_colors
 
         colors = ["#FF0000", "#FF0022", "#00FF00", "#0000FF"]
-        result = merge_similar_colors(colors, threshold=25.0)
+        result = merge_similar_colors(colors, threshold=4.0)
 
         for color in result:
             assert isinstance(color, str)
             assert color.startswith("#")
             assert len(color) == 7
+
+    def test_merge_similar_colors_oklch_grays(self):
+        """RED: Near grays should merge under tight OKLCH ΔE."""
+        from copy_that.application.color_utils import merge_similar_colors
+
+        colors = ["#F8F9FA", "#F7F7F7", "#000000"]
+        result = merge_similar_colors(colors, threshold=2.5)
+
+        assert len(result) == 2  # whites merge, black remains
 
     def test_find_nearest_color_in_palette(self):
         """RED: Should find nearest color in palette."""

--- a/src/copy_that/interfaces/api/schemas.py
+++ b/src/copy_that/interfaces/api/schemas.py
@@ -124,6 +124,9 @@ class ColorTokenResponse(BaseModel):
     closest_css_named: str | None = Field(None, description="Closest CSS named color")
     delta_e_to_dominant: float | None = Field(None, description="Delta E distance to dominant")
     is_neutral: bool | None = Field(None, description="Is neutral/grayscale")
+    background_role: str | None = Field(
+        None, description="Background role label (primary/secondary) for UI or docs"
+    )
 
     # ML/CV model properties
     kmeans_cluster_id: int | None = Field(None, description="K-means cluster ID")


### PR DESCRIPTION
**Summary:**

- Introduced infer_base_spacing to detect the spacing base unit with a confidence score; threaded base_unit_confidence through the CV/AI extractors, services, SSE streaming metadata, and the spacing extraction response schema.
- Updated the multi-extract SSE handler and the AdvancedColorScienceDemo so spacing summaries show “base Npx · confidence XX%”, and the UI now renders the red “New features” tag list plus background/contrast/OKLCH-merge badges with darker “Color Identity/Semantic Names” text.
- Refined the palette/detail layout (grid split, full-height panels, palette card fill) so the new badges and spacing info stay visible alongside the streamed metadata. Tests: pytest tests/unit/application/test_spacing_utils.py.