### PR TITLE
feat: add spacing base confidence metadata and feature badges

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - ./src:/app/src
       - ./tests:/app/tests
       - ./storage:/app/storage
+    env_file:
+      - .env
     environment:
       - ENVIRONMENT=local
       - DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/copy_that
@@ -92,6 +94,8 @@ services:
     volumes:
       - ./src:/app/src
       - ./storage:/app/storage
+    env_file:
+      - .env
     environment:
       - ENVIRONMENT=local
       - DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/copy_that

--- a/frontend/src/components/ColorDetailPanel.css
+++ b/frontend/src/components/ColorDetailPanel.css
@@ -82,6 +82,37 @@
   word-break: break-word;
 }
 
+.feature-note {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 0.45rem;
+  font-size: 0.75rem;
+  color: #dc2626;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.feature-note-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.feature-tag {
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(220, 38, 38, 0.35);
+  background: rgba(220, 38, 38, 0.12);
+  color: #991b1b;
+  font-size: 0.7rem;
+}
+
+.feature-note-title {
+  font-size: 0.65rem;
+  letter-spacing: 0.2px;
+}
+
 .background-badge {
   display: inline-flex;
   align-items: center;
@@ -96,6 +127,26 @@
   border: 1px solid rgba(16, 185, 129, 0.3);
   text-transform: uppercase;
   letter-spacing: 0.25px;
+}
+
+.background-badge.primary {
+  background: rgba(16, 185, 129, 0.2);
+  color: #064e3b;
+  border-color: rgba(16, 185, 129, 0.5);
+}
+
+.background-badge.secondary {
+  background: rgba(14, 165, 233, 0.2);
+  color: #0c4a6e;
+  border-color: rgba(14, 165, 233, 0.5);
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-bottom: 0.35rem;
+  align-items: center;
 }
 
 .merge-badge {
@@ -117,7 +168,7 @@
 .hex-clickable {
   display: inline-block;
   font-size: 1.1rem;
-  color: #4f46e5;
+  color: #0f172a;
   font-family: 'Monaco', 'Courier New', monospace;
   font-weight: 600;
   margin: 0.5rem 0;
@@ -203,7 +254,7 @@
 .code-item code {
   display: block;
   font-size: 0.85rem;
-  color: #e0e0e0;
+  color: #111827;
   font-family: 'Monaco', 'Courier New', monospace;
   word-break: break-all;
 }
@@ -299,7 +350,7 @@
 .props-section h3 {
   margin: 0 0 0.75rem 0;
   font-size: 1rem;
-  color: #e0e0e0;
+  color: #111827;
   text-transform: uppercase;
   letter-spacing: 0.5px;
   font-weight: 600;
@@ -314,19 +365,24 @@
 .info-item,
 .prop-item {
   padding: 0.75rem;
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.12);
   border-radius: 6px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(0, 0, 0, 0.06);
 }
 
 .info-item label,
 .prop-item label {
   display: block;
   font-size: 0.75rem;
-  color: #888;
+  color: #1f2937;
   text-transform: uppercase;
-  margin-bottom: 0.5rem;
-  font-weight: 600;
+  margin-bottom: 0.25rem;
+  font-weight: 700;
+}
+
+.info-item span,
+.prop-item span {
+  color: #0f172a;
 }
 
 .info-item span,
@@ -334,7 +390,7 @@
 .prop-item code {
   display: block;
   font-size: 0.95rem;
-  color: #e0e0e0;
+  color: #0f172a;
   word-break: break-word;
 }
 
@@ -401,7 +457,7 @@
 .semantic-value {
   display: block;
   font-size: 0.9rem;
-  color: #e0e0e0;
+  color: #111827;
 }
 
 /* Prominence */
@@ -529,4 +585,36 @@
   .tab-content {
     padding: 1rem;
   }
+}
+.contrast-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.6rem;
+  height: 24px;
+  margin-top: 0.2rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 999px;
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  letter-spacing: 0.15px;
+  text-transform: uppercase;
+  margin-left: 0.4rem;
+}
+
+.contrast-badge.high {
+  background: rgba(34, 197, 94, 0.18);
+  color: #166534;
+  border-color: rgba(34, 197, 94, 0.5);
+}
+
+.contrast-badge.medium {
+  background: rgba(245, 158, 11, 0.2);
+  color: #78350f;
+  border-color: rgba(245, 158, 11, 0.5);
+}
+
+.contrast-badge.low {
+  background: rgba(248, 113, 113, 0.15);
+  color: #7f1d1d;
+  border-color: rgba(248, 113, 113, 0.4);
 }

--- a/frontend/src/components/ColorDetailPanel.tsx
+++ b/frontend/src/components/ColorDetailPanel.tsx
@@ -27,6 +27,17 @@ export function ColorDetailPanel({ color }: Props) {
     )
   }
 
+  const featureNotes: string[] = []
+  if (color.background_role) {
+    featureNotes.push(`${color.background_role} background`)
+  }
+  if (color.contrast_category && color.contrast_category !== 'background') {
+    featureNotes.push(`Contrast tagging (${color.contrast_category})`)
+  }
+  if (color.count != null && color.count > 1) {
+    featureNotes.push(`OKLCH merged (${color.count} hits)`)
+  }
+
   return (
     <div className="detail-panel">
       {/* Header */}
@@ -39,14 +50,33 @@ export function ColorDetailPanel({ color }: Props) {
             />
             <div className="header-info">
               <h2 className="color-name">{color.name}</h2>
-              {color.background_role && (
-                <span className={`background-badge ${color.background_role}`}>
-                  {color.background_role} background
-                </span>
+              {featureNotes.length > 0 && (
+                <div className="feature-note">
+                  <span className="feature-note-title">New features</span>
+                  <div className="feature-note-items">
+                    {featureNotes.map((item) => (
+                      <span key={item} className="feature-tag">
+                        {item}
+                      </span>
+                    ))}
+                  </div>
+                </div>
               )}
-              {color.count != null && color.count > 1 && (
-                <span className="merge-badge">OKLCH merged</span>
-              )}
+              <div className="badge-row">
+                {color.background_role && (
+                  <span className={`background-badge ${color.background_role}`}>
+                    {color.background_role} background
+                  </span>
+                )}
+                {color.contrast_category && color.contrast_category !== 'background' && (
+                  <span className={`contrast-badge ${color.contrast_category}`}>
+                    Contrast: {color.contrast_category}
+                  </span>
+                )}
+                {color.count != null && color.count > 1 && (
+                  <span className="merge-badge">OKLCH merged</span>
+                )}
+              </div>
               <code
                 className="hex-clickable"
                 onClick={() => void copyToClipboard(color.hex)}
@@ -59,7 +89,6 @@ export function ColorDetailPanel({ color }: Props) {
               </span>
             </div>
           </div>
-
           {color.count != null && color.count > 1 && (
             <div className="count-info">
               <span className="count-value">{color.count}x</span>

--- a/frontend/src/components/ColorTokenDisplay.css
+++ b/frontend/src/components/ColorTokenDisplay.css
@@ -1,10 +1,10 @@
 /* New side-by-side layout */
 .color-tokens.layout-new {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: minmax(320px, 0.38fr) minmax(0, 0.62fr);
   gap: 1rem;
   width: 100%;
-  height: auto;
+  min-height: 680px;
   padding: 0;
   background: var(--color-bg-secondary);
 }
@@ -15,6 +15,13 @@
   border: 1px solid var(--color-neutral-200);
   border-radius: 12px;
   padding: 1rem;
+  min-height: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+  align-items: stretch;
+  height: 100%;
 }
 
 .detail-container {
@@ -24,6 +31,10 @@
   border: 1px solid var(--color-neutral-200);
   border-radius: 12px;
   padding: 1rem;
+  min-height: 640px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 /* Scrollbar styling */
@@ -51,11 +62,13 @@
 /* Mobile layout */
 @media (max-width: 1024px) {
   .color-tokens.layout-new {
-    height: auto;
+    grid-template-columns: 1fr;
+    min-height: 0;
   }
 
-  .palette-container {
-    border-bottom: none;
+  .palette-container,
+  .detail-container {
+    min-height: auto;
   }
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -77,6 +77,7 @@ export interface ColorToken {
   role?: string;  // 'primary', 'secondary', 'accent', 'neutral', etc.
   provenance?: Record<string, number>;  // {"image_1": 0.95, "image_2": 0.88}
   background_role?: string; // primary/secondary background indicator
+  contrast_category?: string; // high/medium/low contrast vs background
 }
 
 /**

--- a/src/copy_that/application/color_extractor.py
+++ b/src/copy_that/application/color_extractor.py
@@ -99,6 +99,9 @@ class ExtractedColorToken(BaseModel):
     background_role: str | None = Field(
         None, description="Background role suggestion (primary/secondary)"
     )
+    contrast_category: str | None = Field(
+        None, description="Contrast category relative to background (high/medium/low)"
+    )
 
     # ML/CV Model Properties (for educational pipeline)
     kmeans_cluster_id: int | None = Field(None, description="K-means cluster assignment")
@@ -429,6 +432,8 @@ Important: Every color MUST have a semantic token name. Be specific and consiste
             dominant_colors = ["#FF6B6B", "#4ECDC4", "#45B7D1"]
 
         background_colors = color_utils.assign_background_roles(colors)
+        primary_background = background_colors[0] if background_colors else None
+        color_utils.apply_contrast_categories(colors, primary_background)
         return ColorExtractionResult(
             colors=colors[:max_colors],
             dominant_colors=dominant_colors[:3],

--- a/src/copy_that/application/cv/spacing_cv_extractor.py
+++ b/src/copy_that/application/cv/spacing_cv_extractor.py
@@ -14,6 +14,7 @@ try:
 except ImportError:  # pragma: no cover - fallback path when OpenCV is absent
     cv2 = None  # type: ignore[assignment]
 
+from copy_that.application import spacing_utils as su
 from copy_that.application.spacing_models import (
     SpacingExtractionResult,
     SpacingScale,
@@ -54,7 +55,7 @@ class CVSpacingExtractor:
         if not values:
             return self._fallback()
 
-        base_unit = self._detect_base_unit(values)
+        base_unit, base_confidence = su.infer_base_spacing(values)
         tokens: list[SpacingToken] = []
         for i, (label, v) in enumerate(zip(self._labels(), values, strict=False)):
             prominence = counts.get(v, 1) / max(len(all_gaps), 1)
@@ -80,6 +81,7 @@ class CVSpacingExtractor:
             tokens=tokens,
             scale_system=self._scale_from_base(base_unit),
             base_unit=base_unit,
+            base_unit_confidence=base_confidence,
             grid_compliance=1.0 if base_unit else 0.5,
             extraction_confidence=0.55,
             min_spacing=min(values),
@@ -134,10 +136,12 @@ class CVSpacingExtractor:
                 zip(["xs", "sm", "md", "lg", "xl", "xxl"], defaults, strict=False)
             )
         ]
+        base_unit, base_confidence = su.infer_base_spacing(defaults)
         return SpacingExtractionResult(
             tokens=tokens,
             scale_system=SpacingScale.FOUR_POINT,
             base_unit=4,
+            base_unit_confidence=base_confidence,
             grid_compliance=1.0,
             extraction_confidence=0.5,
             min_spacing=min(defaults),

--- a/src/copy_that/application/spacing_extractor.py
+++ b/src/copy_that/application/spacing_extractor.py
@@ -18,6 +18,7 @@ from typing import Any
 import requests
 from openai import OpenAI
 
+from . import spacing_utils as su
 from .spacing_models import SpacingExtractionResult, SpacingScale, SpacingToken
 
 logger = logging.getLogger(__name__)
@@ -179,10 +180,16 @@ Rules:
             return self._fallback_spacing(max_tokens)
 
         unique_sorted = sorted(unique_values)
+        base_unit_confidence = 0.0
+        try:
+            base_unit_confidence = su.infer_base_spacing(unique_sorted)[1]
+        except Exception:
+            base_unit_confidence = 0.0
         return SpacingExtractionResult(
             tokens=tokens,
             scale_system=scale_system,
             base_unit=base_unit,
+            base_unit_confidence=base_unit_confidence,
             grid_compliance=grid_compliance if grid_compliance <= 1 else grid_compliance / 100.0,
             extraction_confidence=extraction_confidence,
             min_spacing=unique_sorted[0],
@@ -211,10 +218,12 @@ Rules:
             )
         ]
 
+        base_unit_confidence = su.infer_base_spacing(default_values)[1]
         return SpacingExtractionResult(
             tokens=tokens,
             scale_system=SpacingScale.FOUR_POINT,
             base_unit=base_unit,
+            base_unit_confidence=base_unit_confidence,
             grid_compliance=1.0,
             extraction_confidence=0.65,
             min_spacing=min(default_values),

--- a/src/copy_that/application/spacing_models.py
+++ b/src/copy_that/application/spacing_models.py
@@ -176,6 +176,9 @@ class SpacingExtractionResult(BaseModel):
     tokens: list[SpacingToken] = Field(..., description="Extracted spacing tokens")
     scale_system: SpacingScale = Field(..., description="Detected overall scale system")
     base_unit: int = Field(..., description="Detected base unit in pixels")
+    base_unit_confidence: float = Field(
+        0.0, ge=0, le=1, description="How confident the extractor is in the base unit"
+    )
     grid_compliance: float = Field(
         ..., ge=0, le=1, description="Percentage of values aligned to grid"
     )

--- a/src/copy_that/interfaces/api/multi_extract.py
+++ b/src/copy_that/interfaces/api/multi_extract.py
@@ -73,8 +73,13 @@ async def extract_stream(
                         status_code=404, detail=f"Project {request.project_id} not found"
                     )
 
-            def send(event: str, data: dict[str, Any]) -> str:
-                clean = _sanitize_numbers(data)
+            def send(
+                event: str, data: dict[str, Any], metadata: dict[str, Any] | None = None
+            ) -> str:
+                payload = dict(data)
+                if metadata:
+                    payload["metadata"] = metadata
+                clean = _sanitize_numbers(payload)
                 return f"event: {event}\ndata: {json.dumps(clean, allow_nan=False)}\n\n"
 
             # CV color
@@ -100,6 +105,10 @@ async def extract_stream(
                     "type": "spacing",
                     "source": "cv",
                     "tokens": [t.model_dump() for t in cv_spacing_result.tokens],
+                },
+                {
+                    "base_unit": cv_spacing_result.base_unit,
+                    "base_unit_confidence": cv_spacing_result.base_unit_confidence,
                 },
             )
 
@@ -140,6 +149,10 @@ async def extract_stream(
                     "type": "spacing",
                     "source": "ai",
                     "tokens": [t.model_dump() for t in ai_spacing_result.tokens],
+                },
+                {
+                    "base_unit": ai_spacing_result.base_unit,
+                    "base_unit_confidence": ai_spacing_result.base_unit_confidence,
                 },
             )
 

--- a/src/copy_that/interfaces/api/schemas.py
+++ b/src/copy_that/interfaces/api/schemas.py
@@ -127,6 +127,9 @@ class ColorTokenResponse(BaseModel):
     background_role: str | None = Field(
         None, description="Background role label (primary/secondary) for UI or docs"
     )
+    contrast_category: str | None = Field(
+        None, description="Contrast label versus background (high/medium/low)"
+    )
 
     # ML/CV model properties
     kmeans_cluster_id: int | None = Field(None, description="K-means cluster ID")

--- a/src/copy_that/interfaces/api/spacing.py
+++ b/src/copy_that/interfaces/api/spacing.py
@@ -95,6 +95,7 @@ class SpacingExtractionResponse(BaseModel):
     tokens: list[SpacingTokenResponse]
     scale_system: str
     base_unit: int
+    base_unit_confidence: float
     grid_compliance: float
     extraction_confidence: float
     unique_values: list[int]
@@ -533,6 +534,7 @@ def _result_to_response(
         tokens=token_responses,
         scale_system=result.scale_system.value,
         base_unit=result.base_unit,
+        base_unit_confidence=result.base_unit_confidence,
         grid_compliance=result.grid_compliance,
         extraction_confidence=result.extraction_confidence,
         unique_values=result.unique_values,

--- a/src/copy_that/services/spacing_service.py
+++ b/src/copy_that/services/spacing_service.py
@@ -67,6 +67,7 @@ def merge_spacing(
         tokens=merged_tokens,
         scale_system=ai.scale_system or cv.scale_system,
         base_unit=ai.base_unit or cv.base_unit,
+        base_unit_confidence=ai.base_unit_confidence or cv.base_unit_confidence,
         grid_compliance=ai.grid_compliance or cv.grid_compliance,
         extraction_confidence=ai.extraction_confidence or cv.extraction_confidence,
         unique_values=ai.unique_values or cv.unique_values,

--- a/tests/unit/application/test_spacing_utils.py
+++ b/tests/unit/application/test_spacing_utils.py
@@ -29,3 +29,9 @@ def test_detect_scale_position():
     assert su.detect_scale_position(16, values) == 3
     # nearest fit
     assert su.detect_scale_position(18, values) == 4
+
+
+def test_infer_base_spacing_high_confidence():
+    base, confidence = su.infer_base_spacing([8, 16, 8, 24, 16])
+    assert base == 8
+    assert confidence >= 0.8

--- a/tests/unit/interfaces/api/test_multi_extract.py
+++ b/tests/unit/interfaces/api/test_multi_extract.py
@@ -102,6 +102,7 @@ def _fake_spacing_result() -> SpacingExtractionResult:
         tokens=[tok],
         scale_system="4pt",
         base_unit=4,
+        base_unit_confidence=0.95,
         grid_compliance=1.0,
         extraction_confidence=0.8,
         min_spacing=8,

--- a/tests/unit/test_color_utils.py
+++ b/tests/unit/test_color_utils.py
@@ -5,8 +5,10 @@ import pytest
 from copy_that.application.color_utils import (
     calculate_delta_e,
     calculate_wcag_contrast,
+    categorize_contrast,
     color_similarity,
     compute_all_properties,
+    contrast_ratio,
     ensure_displayable_color,
     find_nearest_color,
     get_closest_css_named,
@@ -517,3 +519,18 @@ class TestComputeAllProperties:
         assert props["temperature"] == "warm"
         assert props["saturation_level"] == "vibrant"
         assert props["is_neutral"] is False
+
+
+def test_contrast_ratio_and_categorize():
+    """Test contrast helpers for high/medium/low thresholds."""
+
+    ratio_high = contrast_ratio("#FFFFFF", "#000000")
+    assert ratio_high >= 20
+    assert categorize_contrast(ratio_high) == "high"
+
+    ratio_medium = contrast_ratio("#FFFFFF", "#777777")
+    assert 3 <= ratio_medium < 7
+    assert categorize_contrast(ratio_medium) == "medium"
+
+    ratio_low = contrast_ratio("#FFFFFF", "#F9F9F9")
+    assert categorize_contrast(ratio_low) == "low"


### PR DESCRIPTION
**Summary**

- Added infer_base_spacing so spacing gaps emit a detected base unit plus confidence; threading that metadata through the CV/AI spacing extractors, merge service, SSE stream, and SpacingExtractionResponse schema means the UI can explain “base 8px · confidence 85%” every time spacing tokens stream in.
- Updated the multi-extract SSE handler and the AdvancedColorScienceDemo so spacing summaries display the base/confidence metadata, and the color detail panel now surfaces red “New features” tags plus background/contrast badges while the palette/detail layout gets a responsive two-column grid with full-height panels.
- Tightened styling (darker “Color Identity/Semantic Names” text, badge layout, palette card filling) and ensured the SSE payload always carries the extra metadata.
- Tests: pytest tests/unit/application/test_spacing_utils.py.