### PR TITLE
Add CV spacing/grid inference and expose segmentation palette in UI

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -295,6 +295,211 @@
 }
 
 /* ========================================
+   SPACING PANEL
+   ======================================== */
+
+.spacing-panel-heading h2 {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.new-feature-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: #b42318;
+  background: #fee4e2;
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
+  letter-spacing: 0.08em;
+}
+
+.spacing-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.spacing-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-md);
+}
+
+.spacing-stat-card {
+  border: 1px solid var(--color-neutral-100);
+  border-radius: 10px;
+  padding: var(--space-md);
+  background: var(--color-neutral-25, #fbfbfb);
+}
+
+.stat-label {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.25rem;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+}
+
+.stat-meta {
+  display: block;
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  margin-top: 0.25rem;
+}
+
+.spacing-scale-chip {
+  font-size: 0.95rem;
+  background: var(--color-neutral-50);
+  padding: 0.15rem 0.75rem;
+  border-radius: 999px;
+}
+
+.spacing-diagnostics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-md);
+}
+
+.spacing-card {
+  border: 1px solid var(--color-neutral-100);
+  border-radius: 12px;
+  padding: var(--space-md);
+  background: #fff;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.04);
+}
+
+.spacing-card.full-width {
+  grid-column: 1 / -1;
+}
+
+.spacing-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-sm);
+}
+
+.spacing-card-value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.spacing-card-text {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+.spacing-card-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.95rem;
+}
+
+.spacing-token-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-md);
+}
+
+.spacing-token-card {
+  border: 1px solid var(--color-neutral-100);
+  border-radius: 10px;
+  padding: var(--space-md);
+  background: var(--color-neutral-25, #fbfbfb);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.spacing-token-value {
+  font-size: 1.4rem;
+  font-weight: 700;
+}
+
+.spacing-token-subvalue {
+  display: inline-block;
+  margin-left: 0.35rem;
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.spacing-token-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.spacing-token-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  background: var(--color-neutral-100);
+  font-size: 0.75rem;
+  width: fit-content;
+}
+
+.spacing-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.35rem;
+  border-radius: 6px;
+  background: var(--color-neutral-100);
+  font-size: 0.75rem;
+  width: fit-content;
+}
+
+.spacing-badge.success {
+  background: #ecfdf3;
+  color: #027a48;
+}
+
+.spacing-component-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-md);
+}
+
+.component-card {
+  border: 1px solid var(--color-neutral-100);
+  border-radius: 10px;
+  padding: var(--space-md);
+  background: var(--color-neutral-50);
+}
+
+.component-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+  margin-bottom: var(--space-sm);
+}
+
+.component-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.9rem;
+}
+
+/* ========================================
    RESPONSIVE DESIGN
    ======================================== */
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -201,6 +201,62 @@
   overflow: visible !important;
 }
 
+.segmentation-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.segmentation-row {
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 10px;
+  align-items: center;
+}
+
+.segmentation-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+  border: 1px solid #e5e7eb;
+}
+
+.segmentation-meta {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 6px;
+  align-items: center;
+}
+
+.segmentation-hex {
+  font-size: 12px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.segmentation-bar {
+  grid-column: 1 / 3;
+  height: 8px;
+  background: #f1f5f9;
+  border-radius: 999px;
+  overflow: hidden;
+  border: 1px solid #e5e7eb;
+}
+
+.segmentation-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #6366f1, #c084fc);
+  border-radius: 999px;
+}
+
+.segmentation-coverage {
+  font-size: 12px;
+  font-weight: 600;
+  color: #4b5563;
+}
+
 /* ========================================
    LOADING STATE
    ======================================== */

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import ImageUploader from './components/ImageUploader'
 import ColorTokenDisplay from './components/ColorTokenDisplay'
 import ShadowTokenList from './components/shadows/ShadowTokenList'
 import './components/shadows/ShadowTokenList.css'
-import type { ColorRampMap, ColorToken, SpacingExtractionResponse } from './types'
+import type { ColorRampMap, ColorToken, SegmentedColor, SpacingExtractionResponse } from './types'
 
 export default function App() {
   // Ensure global scroll isn’t disabled by other styles
@@ -25,6 +25,7 @@ export default function App() {
   const [spacingResult, setSpacingResult] = useState<SpacingExtractionResponse | null>(null)
   const [typographyTokens, setTypographyTokens] = useState<any[]>([])
   const [ramps, setRamps] = useState<ColorRampMap>({})
+  const [segmentedPalette, setSegmentedPalette] = useState<SegmentedColor[] | null>(null)
   const [debugOverlay, setDebugOverlay] = useState<string | null>(null)
   const [error, setError] = useState<string>('')
   const [isLoading, setIsLoading] = useState(false)
@@ -116,6 +117,7 @@ export default function App() {
               onShadowsExtracted={handleShadowsExtracted}
               onRampsExtracted={setRamps}
               onDebugOverlay={setDebugOverlay}
+              onSegmentationExtracted={setSegmentedPalette}
               onError={handleError}
               onLoadingChange={handleLoadingChange}
             />
@@ -141,7 +143,14 @@ export default function App() {
                 </div>
               </div>
             )}
-            {colors.length > 0 && <ColorTokenDisplay colors={colors} ramps={ramps} debugOverlay={debugOverlay ?? undefined} />}
+            {colors.length > 0 && (
+              <ColorTokenDisplay
+                colors={colors}
+                ramps={ramps}
+                segmentedPalette={segmentedPalette ?? undefined}
+                debugOverlay={debugOverlay ?? undefined}
+              />
+            )}
             {!hasUpload && colors.length === 0 && (
               <div className="empty-state">
                 <div className="empty-content">

--- a/frontend/src/components/ColorTokenDisplay.tsx
+++ b/frontend/src/components/ColorTokenDisplay.tsx
@@ -2,7 +2,7 @@ import './ColorTokenDisplay.css'
 import { ColorPaletteSelector } from './ColorPaletteSelector'
 import { ColorDetailPanel } from './ColorDetailPanel'
 import { useState, useMemo, useEffect } from 'react'
-import { ColorRampMap, ColorToken } from '../types'
+import { ColorRampMap, ColorToken, SegmentedColor } from '../types'
 
 interface Props {
   colors?: ColorToken[]
@@ -10,9 +10,10 @@ interface Props {
   token?: Partial<ColorToken>
   ramps?: ColorRampMap
   debugOverlay?: string
+  segmentedPalette?: SegmentedColor[]
 }
 
-export default function ColorTokenDisplay({ colors, token, ramps, debugOverlay }: Props) {
+export default function ColorTokenDisplay({ colors, token, ramps, debugOverlay, segmentedPalette }: Props) {
   // Normalize to colors array - support both props patterns
   const normalizedColors = useMemo(() => {
     if (colors && colors.length > 0) {
@@ -60,6 +61,31 @@ export default function ColorTokenDisplay({ colors, token, ramps, debugOverlay }
           selectedIndex={selectedIndex}
           onSelectColor={setSelectedIndex}
         />
+        {segmentedPalette && segmentedPalette.length > 0 && (
+          <div className="ramp-section">
+            <div className="ramp-header">
+              <div className="ramp-title">Segmented coverage</div>
+              <div className="ramp-subtitle">Top clusters from CV segmentation</div>
+            </div>
+            <div className="segmentation-list">
+              {segmentedPalette.slice(0, 6).map((seg) => (
+                <div className="segmentation-row" key={`${seg.hex}-${seg.coverage}`}>
+                  <div className="segmentation-swatch" style={{ background: seg.hex }} />
+                  <div className="segmentation-meta">
+                    <div className="segmentation-hex">{seg.hex}</div>
+                    <div className="segmentation-bar">
+                      <div
+                        className="segmentation-fill"
+                        style={{ width: `${Math.min(seg.coverage, 100)}%` }}
+                      />
+                    </div>
+                    <div className="segmentation-coverage">{seg.coverage}%</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
         {accentRampEntries.length > 0 && (
           <div className="ramp-section">
             <div className="ramp-header">

--- a/frontend/src/components/ImageUploader.tsx
+++ b/frontend/src/components/ImageUploader.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import './ImageUploader.css'
-import { ColorRampMap, ColorToken, SpacingExtractionResponse } from '../types'
+import { ColorRampMap, ColorToken, SegmentedColor, SpacingExtractionResponse } from '../types'
 import { ApiClient } from '../api/client'
 import {
   isValidImageFile,
@@ -16,6 +16,7 @@ interface Props {
   onShadowsExtracted?: (shadows: any[]) => void
   onRampsExtracted?: (ramps: ColorRampMap) => void
   onDebugOverlay?: (overlayBase64: string | null) => void
+  onSegmentationExtracted?: (segments: SegmentedColor[] | null) => void
   onError: (error: string) => void
   onLoadingChange: (loading: boolean) => void
 }
@@ -35,7 +36,7 @@ interface StreamEvent {
   background_colors?: string[]
   text_roles?: Array<{ hex: string; role: string; contrast?: number }>
   ramps?: ColorRampMap
-  debug?: { overlay_png_base64?: string }
+  debug?: { overlay_png_base64?: string; segmented_palette?: SegmentedColor[] }
 }
 
 export default function ImageUploader({
@@ -46,6 +47,7 @@ export default function ImageUploader({
   onShadowsExtracted,
   onRampsExtracted,
   onDebugOverlay,
+  onSegmentationExtracted,
   onError,
   onLoadingChange,
 }: Props) {
@@ -132,6 +134,7 @@ export default function ImageUploader({
       console.log('Starting color extraction...')
       onLoadingChange(true)
       onError('')
+      onSegmentationExtracted?.(null)
 
       // Ensure project exists
       console.log('Ensuring project exists...')
@@ -273,6 +276,9 @@ export default function ImageUploader({
                 if (event.debug?.overlay_png_base64) {
                   debugOverlay = event.debug.overlay_png_base64
                   onDebugOverlay?.(debugOverlay)
+                }
+                if (event.debug?.segmented_palette && onSegmentationExtracted) {
+                  onSegmentationExtracted(event.debug.segmented_palette)
                 }
               }
             } catch (e) {

--- a/frontend/src/components/ImageUploader.tsx
+++ b/frontend/src/components/ImageUploader.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import './ImageUploader.css'
-import { ColorRampMap, ColorToken } from '../types'
+import { ColorRampMap, ColorToken, SpacingExtractionResponse } from '../types'
 import { ApiClient } from '../api/client'
 import {
   isValidImageFile,
@@ -12,7 +12,7 @@ interface Props {
   projectId: number | null
   onProjectCreated: (id: number) => void
   onColorExtracted: (colors: ColorToken[]) => void
-  onSpacingExtracted?: (tokens: any[]) => void
+  onSpacingExtracted?: (result: SpacingExtractionResponse | null) => void
   onShadowsExtracted?: (shadows: any[]) => void
   onRampsExtracted?: (ramps: ColorRampMap) => void
   onDebugOverlay?: (overlayBase64: string | null) => void
@@ -170,11 +170,14 @@ export default function ImageUploader({
             }),
           })
           if (resp.ok) {
-            const data = await resp.json()
-            onSpacingExtracted(data.tokens ?? [])
+            const data: SpacingExtractionResponse = await resp.json()
+            onSpacingExtracted(data)
+          } else {
+            onSpacingExtracted(null)
           }
         } catch (err) {
           console.warn('Spacing extraction failed', err)
+          onSpacingExtracted(null)
         }
       }
 
@@ -198,6 +201,9 @@ export default function ImageUploader({
         }
       }
 
+      if (onSpacingExtracted) {
+        onSpacingExtracted(null)
+      }
       void kickOffSpacing()
       void kickOffShadows()
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -97,6 +97,11 @@ export interface ColorRampEntry {
 
 export type ColorRampMap = Record<string, ColorRampEntry>
 
+export interface SegmentedColor {
+  hex: string
+  coverage: number
+}
+
 export interface SpacingTokenResponse {
   value_px: number
   value_rem: number

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -97,6 +97,52 @@ export interface ColorRampEntry {
 
 export type ColorRampMap = Record<string, ColorRampEntry>
 
+export interface SpacingTokenResponse {
+  value_px: number
+  value_rem: number
+  name: string
+  confidence: number
+  semantic_role?: string | null
+  spacing_type?: string | null
+  role?: string | null
+  grid_aligned?: boolean | null
+  tailwind_class?: string | null
+}
+
+export interface SpacingExtractionResponse {
+  tokens: SpacingTokenResponse[]
+  scale_system: string
+  base_unit: number
+  grid_compliance: number
+  extraction_confidence: number
+  unique_values: number[]
+  min_spacing: number
+  max_spacing: number
+  cv_gap_diagnostics?: Record<string, unknown> | null
+  base_alignment?: Record<string, unknown> | null
+  cv_gaps_sample?: number[] | null
+  baseline_spacing?: {
+    value_px: number
+    confidence: number
+  } | null
+  component_spacing_metrics?: Array<{
+    index?: number
+    box?: [number, number, number, number]
+    padding?: Record<string, number>
+    padding_confidence?: number
+    margin?: Record<string, number>
+    neighbor_gap?: number
+  }> | null
+  grid_detection?: {
+    columns?: number
+    gutter_px?: number
+    margin_left?: number
+    margin_right?: number
+    confidence?: number
+  } | null
+  design_tokens?: Record<string, unknown> | null
+}
+
 /**
  * Project - User project context
  *

--- a/src/copy_that/application/cv/color_cv_extractor.py
+++ b/src/copy_that/application/cv/color_cv_extractor.py
@@ -180,11 +180,17 @@ class CVColorExtractor:
             )
 
         dominant = [t.hex for t in tokens[:3]]
+        segmented_palette = self._segment_palette(views.get("cv_bgr"))
         debug_overlay = generate_debug_overlay(
             views["cv_bgr"],
             background_hex=bg_hex,
             text_hexes=[t.hex for t in tokens if (t.extraction_metadata or {}).get("text_role")],
         )
+        debug_payload: dict[str, Any] = {}
+        if debug_overlay:
+            debug_payload["overlay_png_base64"] = debug_overlay
+        if segmented_palette:
+            debug_payload["segmented_palette"] = segmented_palette
         result = ColorExtractionResult(
             colors=tokens,
             dominant_colors=dominant,
@@ -192,7 +198,7 @@ class CVColorExtractor:
             extraction_confidence=0.6,
             extractor_used="cv",
             background_colors=backgrounds,
-            debug={"overlay_png_base64": debug_overlay} if debug_overlay else None,
+            debug=debug_payload or None,
         )
         if token_repo:
             self._store_tokens(tokens, token_repo, token_namespace)
@@ -307,6 +313,42 @@ class CVColorExtractor:
             return best or bg_hex
         except Exception:
             return None
+
+    @staticmethod
+    def _segment_palette(cv_bgr: Any, k: int = 8) -> list[dict[str, Any]]:
+        """
+        Lightweight segmentation using k-means to surface dominant regions and coverage.
+        Returns a list of dicts with hex and coverage percentage.
+        """
+        if cv_bgr is None:
+            return []
+        try:
+            import cv2  # type: ignore[import-not-found]
+
+            data = np.reshape(cv_bgr, (-1, 3)).astype(np.float32)
+            k = max(2, min(k, 12))
+            criteria = (1, 10, 1.0)  # type: ignore[assignment]
+            _, labels, centers = cast(
+                tuple[int, np.ndarray[Any, Any], np.ndarray[Any, Any]],
+                cv2.kmeans(data, k, None, criteria, 3, cv2.KMEANS_PP_CENTERS),  # type: ignore[name-defined]
+            )
+            counts = np.bincount(labels.flatten(), minlength=k)
+            total = float(np.sum(counts)) or 1.0
+            palette: list[dict[str, Any]] = []
+            for center, count in zip(centers, counts, strict=False):
+                r, g, b = [int(round(v)) for v in center]
+                hex_val = f"#{r:02x}{g:02x}{b:02x}"
+                palette.append(
+                    {
+                        "hex": hex_val,
+                        "coverage": round((float(count) / total) * 100.0, 2),
+                    }
+                )
+            # Sort by coverage descending
+            palette.sort(key=lambda p: p["coverage"], reverse=True)
+            return palette
+        except Exception:
+            return []
 
     @staticmethod
     def _superpixel_palette(cv_bgr: Any) -> list[tuple[tuple[int, int, int], int]]:

--- a/src/copy_that/application/cv/color_cv_extractor.py
+++ b/src/copy_that/application/cv/color_cv_extractor.py
@@ -330,7 +330,7 @@ class CVColorExtractor:
             criteria = (1, 10, 1.0)  # type: ignore[assignment]
             _, labels, centers = cast(
                 tuple[int, np.ndarray[Any, Any], np.ndarray[Any, Any]],
-                cv2.kmeans(data, k, None, criteria, 3, cv2.KMEANS_PP_CENTERS),  # type: ignore[name-defined]
+                cv2.kmeans(data, k, None, criteria, 3, cv2.KMEANS_PP_CENTERS),  # type: ignore[name-defined,call-overload]
             )
             counts = np.bincount(labels.flatten(), minlength=k)
             total = float(np.sum(counts)) or 1.0

--- a/src/copy_that/application/cv/grid_cv_extractor.py
+++ b/src/copy_that/application/cv/grid_cv_extractor.py
@@ -1,0 +1,86 @@
+"""
+Grid inference utilities for spacing analysis.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from statistics import median
+
+
+def infer_grid_from_bboxes(
+    bboxes: Iterable[tuple[int, int, int, int]],
+    canvas_width: int,
+    tolerance_ratio: float = 0.05,
+) -> dict[str, float | int] | None:
+    """
+    Infer column count, gutter, and margins from bounding boxes.
+
+    Args:
+        bboxes: iterable of (x, y, w, h)
+        canvas_width: width of the analyzed canvas/image
+        tolerance_ratio: grouping tolerance relative to canvas width
+
+    Returns:
+        Dict with columns/gutter/margins/confidence or None if insufficient data.
+    """
+
+    boxes = [box for box in bboxes if box[2] > 4 and box[3] > 4]
+    if len(boxes) < 2 or canvas_width <= 0:
+        return None
+
+    tolerance = max(8, int(canvas_width * tolerance_ratio))
+    groups: list[dict[str, float | list[tuple[int, int, int, int]]]] = []
+
+    for x, y, w, h in sorted(boxes, key=lambda b: b[0]):
+        center = x + w / 2.0
+        placed = False
+        for group in groups:
+            if abs(center - group["center"]) <= tolerance:  # type: ignore[index]
+                group["center"] = (group["center"] * len(group["boxes"]) + center) / (
+                    len(group["boxes"]) + 1
+                )
+                group["min_left"] = min(group["min_left"], x)
+                group["max_right"] = max(group["max_right"], x + w)
+                group["boxes"].append((x, y, w, h))
+                placed = True
+                break
+        if not placed:
+            groups.append(
+                {
+                    "center": center,
+                    "min_left": x,
+                    "max_right": x + w,
+                    "boxes": [(x, y, w, h)],
+                }
+            )
+
+    if len(groups) < 2:
+        return None
+
+    groups.sort(key=lambda g: g["center"])  # type: ignore[index]
+    gutter_values: list[float] = []
+    for idx in range(len(groups) - 1):
+        right = groups[idx]["max_right"]
+        left = groups[idx + 1]["min_left"]
+        gutter = left - right
+        if gutter > 0:
+            gutter_values.append(gutter)
+
+    if not gutter_values:
+        return None
+
+    margin_left = max(0, min(g["min_left"] for g in groups))
+    margin_right = max(0, canvas_width - max(g["max_right"] for g in groups))
+
+    total_boxes = len(boxes)
+    grouped_boxes = sum(len(g["boxes"]) for g in groups)
+    confidence = min(1.0, grouped_boxes / max(total_boxes, 1))
+
+    return {
+        "columns": len(groups),
+        "gutter_px": int(round(median(gutter_values))),
+        "margin_left": int(round(margin_left)),
+        "margin_right": int(round(margin_right)),
+        "confidence": round(confidence, 4),
+    }

--- a/src/copy_that/application/cv/grid_cv_extractor.py
+++ b/src/copy_that/application/cv/grid_cv_extractor.py
@@ -6,6 +6,14 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from statistics import median
+from typing import TypedDict
+
+
+class _GridGroup(TypedDict):
+    center: float
+    min_left: int
+    max_right: int
+    boxes: list[tuple[int, int, int, int]]
 
 
 def infer_grid_from_bboxes(
@@ -30,13 +38,13 @@ def infer_grid_from_bboxes(
         return None
 
     tolerance = max(8, int(canvas_width * tolerance_ratio))
-    groups: list[dict[str, float | list[tuple[int, int, int, int]]]] = []
+    groups: list[_GridGroup] = []
 
     for x, y, w, h in sorted(boxes, key=lambda b: b[0]):
         center = x + w / 2.0
         placed = False
         for group in groups:
-            if abs(center - group["center"]) <= tolerance:  # type: ignore[index]
+            if abs(center - group["center"]) <= tolerance:
                 group["center"] = (group["center"] * len(group["boxes"]) + center) / (
                     len(group["boxes"]) + 1
                 )
@@ -58,7 +66,7 @@ def infer_grid_from_bboxes(
     if len(groups) < 2:
         return None
 
-    groups.sort(key=lambda g: g["center"])  # type: ignore[index]
+    groups.sort(key=lambda g: g["center"])
     gutter_values: list[float] = []
     for idx in range(len(groups) - 1):
         right = groups[idx]["max_right"]

--- a/src/copy_that/application/cv/spacing_cv_extractor.py
+++ b/src/copy_that/application/cv/spacing_cv_extractor.py
@@ -7,6 +7,7 @@ Adds prominence metadata and base unit/scale info for UI display.
 from __future__ import annotations
 
 import base64
+from typing import Any
 
 try:
     import cv2
@@ -242,9 +243,9 @@ class CVSpacingExtractor:
 
     def _infer_component_spacing_metrics(
         self, bboxes: list[tuple[int, int, int, int]], canvas_shape: tuple[int, int]
-    ) -> list[dict]:
+    ) -> list[dict[str, Any]]:
         height, width = canvas_shape
-        metrics: list[dict] = []
+        metrics: list[dict[str, Any]] = []
         for idx, outer in enumerate(bboxes):
             ox, oy, ow, oh = outer
             outer_area = max(ow * oh, 1)

--- a/src/copy_that/application/cv/spacing_cv_extractor.py
+++ b/src/copy_that/application/cv/spacing_cv_extractor.py
@@ -14,10 +14,12 @@ except ImportError:  # pragma: no cover - fallback path when OpenCV is absent
     cv2 = None  # type: ignore[assignment]
 
 from copy_that.application import spacing_utils as su
+from copy_that.application.cv.grid_cv_extractor import infer_grid_from_bboxes
 from copy_that.application.spacing_models import (
     SpacingExtractionResult,
     SpacingScale,
     SpacingToken,
+    SpacingType,
 )
 from cv_pipeline.preprocess import preprocess_image
 from cv_pipeline.primitives import components_to_bboxes, gaps_from_bboxes
@@ -48,13 +50,17 @@ class CVSpacingExtractor:
         if not all_gaps:
             return self._fallback()
 
-        clustered = su.cluster_spacing_values(all_gaps, tolerance=0.15)
-        if not clustered:
+        base_unit, base_confidence, normalized_values = su.infer_base_spacing_robust(all_gaps)
+        if not normalized_values:
+            normalized_values = su.cluster_spacing_values(all_gaps, tolerance=0.15)
+        if not normalized_values:
             return self._fallback()
-        base_unit, base_confidence = su.infer_base_spacing(clustered)
         base_alignment = su.compare_base_units(self.expected_base_px, base_unit, tolerance=1)
-        counts = {v: all_gaps.count(v) for v in clustered}
-        values = clustered[: self.max_tokens]
+        counts: dict[int, int] = dict.fromkeys(normalized_values, 0)
+        for gap in all_gaps:
+            nearest = min(normalized_values, key=lambda candidate: abs(candidate - gap))
+            counts[nearest] = counts.get(nearest, 0) + 1
+        values = normalized_values[: self.max_tokens]
         tokens: list[SpacingToken] = []
         for i, (label, v) in enumerate(zip(self._labels(), values, strict=False)):
             prominence = counts.get(v, 1) / max(len(all_gaps), 1)
@@ -76,6 +82,39 @@ class CVSpacingExtractor:
                 )
             )
 
+        baseline_spacing = su.detect_baseline_spacing_from_bboxes(bboxes)
+        if baseline_spacing:
+            baseline_value, baseline_conf = baseline_spacing
+            if baseline_value > 0:
+                if baseline_value not in values:
+                    values.append(baseline_value)
+                    values.sort()
+                tokens.append(
+                    SpacingToken(
+                        value_px=int(baseline_value),
+                        name="spacing-baseline",
+                        semantic_role="baseline rhythm",
+                        spacing_type=SpacingType.STACK,
+                        category="cv",
+                        confidence=min(0.95, 0.5 + 0.4 * baseline_conf),
+                        usage=["typography"],
+                        scale_position=len(values) - 1,
+                        base_unit=base_unit,
+                        scale_system=self._scale_from_base(base_unit),
+                        grid_aligned=base_unit > 0 and baseline_value % base_unit == 0,
+                        prominence_percentage=None,
+                        extraction_metadata={
+                            "source": "cv",
+                            "baseline_confidence": baseline_conf,
+                        },
+                    )
+                )
+        else:
+            baseline_spacing = None
+
+        component_metrics = self._infer_component_spacing_metrics(bboxes, gray.shape)
+        grid_detection = infer_grid_from_bboxes(bboxes, canvas_width=gray.shape[1])
+
         return SpacingExtractionResult(
             tokens=tokens,
             scale_system=self._scale_from_base(base_unit),
@@ -89,6 +128,11 @@ class CVSpacingExtractor:
             cv_gap_diagnostics=su.cross_check_gaps(all_gaps, base_unit, tolerance_px=1.0),
             base_alignment=base_alignment,
             cv_gaps_sample=all_gaps[:20],
+            baseline_spacing={"value_px": baseline_spacing[0], "confidence": baseline_spacing[1]}
+            if baseline_spacing
+            else None,
+            component_spacing_metrics=component_metrics or None,
+            grid_detection=grid_detection,
         )
 
     def extract_from_base64(self, image_base64: str) -> SpacingExtractionResult:
@@ -152,4 +196,89 @@ class CVSpacingExtractor:
             cv_gap_diagnostics=None,
             base_alignment=su.compare_base_units(None, 4, tolerance=1),
             cv_gaps_sample=None,
+            baseline_spacing=None,
+            component_spacing_metrics=None,
+            grid_detection=None,
         )
+
+    @staticmethod
+    def _is_child(inner: tuple[int, int, int, int], outer: tuple[int, int, int, int]) -> bool:
+        tolerance = 2
+        ix, iy, iw, ih = inner
+        ox, oy, ow, oh = outer
+        return (
+            ix >= ox + tolerance
+            and iy >= oy + tolerance
+            and ix + iw <= ox + ow - tolerance
+            and iy + ih <= oy + oh - tolerance
+        )
+
+    @staticmethod
+    def _neighbor_gap(
+        target: tuple[int, int, int, int],
+        bboxes: list[tuple[int, int, int, int]],
+    ) -> float | None:
+        tx, ty, tw, th = target
+        tx2 = tx + tw
+        ty2 = ty + th
+        gaps: list[float] = []
+        for box in bboxes:
+            if box is target:
+                continue
+            x, y, w, h = box
+            x2 = x + w
+            y2 = y + h
+            if x >= tx2:
+                gaps.append(x - tx2)
+            elif tx >= x2:
+                gaps.append(tx - x2)
+            if y >= ty2:
+                gaps.append(y - ty2)
+            elif ty >= y2:
+                gaps.append(ty - y2)
+        if not gaps:
+            return None
+        return min(gaps)
+
+    def _infer_component_spacing_metrics(
+        self, bboxes: list[tuple[int, int, int, int]], canvas_shape: tuple[int, int]
+    ) -> list[dict]:
+        height, width = canvas_shape
+        metrics: list[dict] = []
+        for idx, outer in enumerate(bboxes):
+            ox, oy, ow, oh = outer
+            outer_area = max(ow * oh, 1)
+            children = [
+                child for child in bboxes if child is not outer and self._is_child(child, outer)
+            ]
+            if not children:
+                continue
+            cx1 = min(child[0] for child in children)
+            cy1 = min(child[1] for child in children)
+            cx2 = max(child[0] + child[2] for child in children)
+            cy2 = max(child[1] + child[3] for child in children)
+            padding = {
+                "top": max(0, cy1 - oy),
+                "bottom": max(0, (oy + oh) - cy2),
+                "left": max(0, cx1 - ox),
+                "right": max(0, (ox + ow) - cx2),
+            }
+            child_area = sum(child[2] * child[3] for child in children)
+            padding_conf = min(1.0, child_area / outer_area)
+            margins = {
+                "top": max(0, oy),
+                "bottom": max(0, height - (oy + oh)),
+                "left": max(0, ox),
+                "right": max(0, width - (ox + ow)),
+            }
+            metrics.append(
+                {
+                    "index": idx,
+                    "box": [ox, oy, ow, oh],
+                    "padding": padding,
+                    "padding_confidence": round(padding_conf, 4),
+                    "margin": margins,
+                    "neighbor_gap": self._neighbor_gap(outer, bboxes),
+                }
+            )
+        return metrics

--- a/src/copy_that/application/cv/spacing_cv_extractor.py
+++ b/src/copy_that/application/cv/spacing_cv_extractor.py
@@ -20,7 +20,7 @@ from copy_that.application.spacing_models import (
     SpacingToken,
 )
 from cv_pipeline.preprocess import preprocess_image
-from cv_pipeline.primitives import bounding_boxes_from_contours, measure_spacing_gaps
+from cv_pipeline.primitives import components_to_bboxes, gaps_from_bboxes
 
 
 class CVSpacingExtractor:
@@ -39,11 +39,11 @@ class CVSpacingExtractor:
         except Exception:
             return self._fallback()
 
-        bboxes = bounding_boxes_from_contours(gray)
+        bboxes = components_to_bboxes(gray)
         if len(bboxes) < 2:
             return self._fallback()
 
-        x_gaps, y_gaps = measure_spacing_gaps(bboxes)
+        x_gaps, y_gaps = gaps_from_bboxes(bboxes)
         all_gaps = [float(v) for v in x_gaps + y_gaps]
         if not all_gaps:
             return self._fallback()

--- a/src/copy_that/application/spacing_models.py
+++ b/src/copy_that/application/spacing_models.py
@@ -6,6 +6,7 @@ Follows the pattern of color_extractor.py ExtractedColorToken.
 """
 
 from enum import Enum
+from typing import Any
 
 from pydantic import BaseModel, Field, computed_field
 
@@ -200,6 +201,15 @@ class SpacingExtractionResult(BaseModel):
     )
     cv_gaps_sample: list[float] | None = Field(
         default=None, description="Sample of CV-measured gaps for QA/debug."
+    )
+    baseline_spacing: dict | None = Field(
+        default=None, description="Detected vertical rhythm/baseline spacing info."
+    )
+    component_spacing_metrics: list[dict[str, Any]] | None = Field(
+        default=None, description="Per-component padding/margin heuristics."
+    )
+    grid_detection: dict | None = Field(
+        default=None, description="Detected grid metadata (columns, gutter, margins)."
     )
 
 

--- a/src/copy_that/interfaces/api/colors.py
+++ b/src/copy_that/interfaces/api/colors.py
@@ -688,11 +688,13 @@ async def extract_colors_streaming(
             color_payloads: list[dict[str, Any]] = []
             for idx, color_model in enumerate(processed_colors):
                 payload = color_model.model_dump(exclude_none=True)
-                stored_color = stored_colors[idx] if idx < len(stored_colors) else None
-                if stored_color is not None:
-                    payload["id"] = stored_color.id
-                    payload["project_id"] = stored_color.project_id
-                    payload["extraction_job_id"] = stored_color.extraction_job_id
+                stored_color_model: ColorToken | None = (
+                    stored_colors[idx] if idx < len(stored_colors) else None
+                )
+                if stored_color_model is not None:
+                    payload["id"] = stored_color_model.id
+                    payload["project_id"] = stored_color_model.project_id
+                    payload["extraction_job_id"] = stored_color_model.extraction_job_id
                 color_payloads.append(_sanitize_json_value(payload))
 
             debug_value = getattr(raw_result, "debug", None)

--- a/src/copy_that/interfaces/api/colors.py
+++ b/src/copy_that/interfaces/api/colors.py
@@ -567,7 +567,6 @@ async def extract_colors_streaming(
                 raw_result.colors, getattr(raw_result, "dominant_colors", None)
             )
             color_palette = _safe_str(getattr(raw_result, "color_palette", ""))
-            extractor_used = _safe_str(extractor_name or getattr(raw_result, "extractor_used", ""))
             dominant_colors = list(getattr(raw_result, "dominant_colors", []) or [])
             try:
                 extraction_confidence = float(
@@ -575,22 +574,13 @@ async def extract_colors_streaming(
                 )
             except Exception:
                 extraction_confidence = 0.0
-            extraction_result = ColorExtractionResult(
-                colors=processed_colors,
-                dominant_colors=dominant_colors,
-                color_palette=color_palette,
-                extraction_confidence=extraction_confidence,
-                extractor_used=extractor_used,
-                background_colors=backgrounds,
-            )
-
             # Send Phase 1 results immediately
             phase1_data = json.dumps(
                 {
                     "phase": 1,
                     "status": "colors_extracted",
-                    "color_count": len(extraction_result.colors),
-                    "message": f"Extracted {len(extraction_result.colors)} colors using fast algorithms",
+                    "color_count": len(processed_colors),
+                    "message": f"Extracted {len(processed_colors)} colors using fast algorithms",
                 }
             )
             yield f"data: {phase1_data}\n\n"
@@ -604,8 +594,8 @@ async def extract_colors_streaming(
                 status="completed",
                 result_data=json.dumps(
                     {
-                        "color_count": len(extraction_result.colors),
-                        "palette": extraction_result.color_palette,
+                        "color_count": len(processed_colors),
+                        "palette": color_palette,
                     },
                     default=str,
                 ),
@@ -615,7 +605,7 @@ async def extract_colors_streaming(
 
             # Store color tokens - keep track for later use
             stored_colors: list[ColorToken] = []
-            for i, color in enumerate(extraction_result.colors):
+            for i, color in enumerate(processed_colors):
                 color_token = ColorToken(
                     project_id=request.project_id,
                     extraction_job_id=extraction_job.id,
@@ -657,13 +647,13 @@ async def extract_colors_streaming(
                 stored_colors.append(color_token)
 
                 # Stream each color as it's processed
-                if (i + 1) % 5 == 0 or i == len(extraction_result.colors) - 1:
+                if (i + 1) % 5 == 0 or i == len(processed_colors) - 1:
                     streaming_data = json.dumps(
                         {
                             "phase": 1,
                             "status": "colors_streaming",
-                            "progress": (i + 1) / len(extraction_result.colors),
-                            "message": f"Processed {i + 1}/{len(extraction_result.colors)} colors",
+                            "progress": (i + 1) / len(processed_colors),
+                            "message": f"Processed {i + 1}/{len(processed_colors)} colors",
                         }
                     )
                     yield f"data: {streaming_data}\n\n"
@@ -674,9 +664,7 @@ async def extract_colors_streaming(
             # Phase 2: Return complete extraction with all color data from database
             shadow_tokens = _default_shadow_tokens(stored_colors)
             ramp_repo = InMemoryTokenRepository()
-            ramp_tokens = _add_color_ramps(
-                ramp_repo, extraction_result.colors, "token/color/stream"
-            )
+            ramp_tokens = _add_color_ramps(ramp_repo, processed_colors, "token/color/stream")
             accent_tokens = []
             text_roles = []
             for stored_color in stored_colors:
@@ -697,28 +685,41 @@ async def extract_colors_streaming(
                             "contrast": meta.get("contrast_to_background"),
                         }
                     )
-            complete_data = json.dumps(
+            color_payloads: list[dict[str, Any]] = []
+            for idx, color_model in enumerate(processed_colors):
+                payload = color_model.model_dump(exclude_none=True)
+                stored_color = stored_colors[idx] if idx < len(stored_colors) else None
+                if stored_color is not None:
+                    payload["id"] = stored_color.id
+                    payload["project_id"] = stored_color.project_id
+                    payload["extraction_job_id"] = stored_color.extraction_job_id
+                color_payloads.append(_sanitize_json_value(payload))
+
+            debug_value = getattr(raw_result, "debug", None)
+            if debug_value is not None and not isinstance(debug_value, (dict, list, str)):
+                debug_value = None
+
+            complete_payload = _sanitize_json_value(
                 {
                     "phase": 2,
                     "status": "extraction_complete",
-                    "summary": extraction_result.color_palette,
-                    "dominant_colors": extraction_result.dominant_colors,
-                    "extraction_confidence": extraction_result.extraction_confidence,
+                    "summary": color_palette,
+                    "dominant_colors": dominant_colors,
+                    "extraction_confidence": extraction_confidence,
                     "extractor_used": extractor_name,
-                    "colors": [serialize_color_token(color) for color in stored_colors],
+                    "colors": color_payloads,
                     "shadows": shadow_tokens,
-                    "background_colors": extraction_result.background_colors,
+                    "background_colors": backgrounds,
                     "text_roles": text_roles,
                     "accent_tokens": accent_tokens,
                     "ramps": ramp_to_dict(ramp_tokens) if ramp_tokens else {},
-                    "debug": extraction_result.debug,
-                },
-                default=str,
+                    "debug": debug_value,
+                }
             )
-            yield f"data: {complete_data}\n\n"
+            yield f"data: {json.dumps(complete_payload, default=str)}\n\n"
 
             logger.info(
-                f"Extracted {len(extraction_result.colors)} colors for project {request.project_id}"
+                f"Extracted {len(processed_colors)} colors for project {request.project_id}"
             )
 
         except Exception as e:

--- a/src/copy_that/services/spacing_service.py
+++ b/src/copy_that/services/spacing_service.py
@@ -73,6 +73,12 @@ def merge_spacing(
         unique_values=ai.unique_values or cv.unique_values,
         min_spacing=ai.min_spacing or cv.min_spacing,
         max_spacing=ai.max_spacing or cv.max_spacing,
+        cv_gap_diagnostics=ai.cv_gap_diagnostics or cv.cv_gap_diagnostics,
+        base_alignment=ai.base_alignment or cv.base_alignment,
+        cv_gaps_sample=ai.cv_gaps_sample or cv.cv_gaps_sample,
+        baseline_spacing=ai.baseline_spacing or cv.baseline_spacing,
+        component_spacing_metrics=ai.component_spacing_metrics or cv.component_spacing_metrics,
+        grid_detection=ai.grid_detection or cv.grid_detection,
     )
 
 

--- a/src/cv_pipeline/primitives.py
+++ b/src/cv_pipeline/primitives.py
@@ -127,3 +127,107 @@ def measure_spacing_gaps(
             y_gaps.append(gap)
 
     return x_gaps, y_gaps
+
+
+def components_to_bboxes(
+    gray: NDArray[np.uint8],
+    *,
+    min_area: int = 64,
+    open_iterations: int = 1,
+    close_iterations: int = 2,
+) -> list[tuple[int, int, int, int]]:
+    """Detect connected components with morphology + contours.
+
+    Returns a list of bounding boxes (x, y, w, h) sorted by row/column.
+    """
+
+    blurred = cv2.GaussianBlur(gray, (5, 5), 0)
+    mean_intensity = float(np.mean(blurred.astype(np.float32)))
+    thresh_type = cv2.THRESH_BINARY_INV if mean_intensity > 127 else cv2.THRESH_BINARY
+    _, binary = cv2.threshold(blurred, 0, 255, thresh_type + cv2.THRESH_OTSU)
+
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (3, 3))
+    opened = cv2.morphologyEx(binary, cv2.MORPH_OPEN, kernel, iterations=open_iterations)
+    processed = cv2.morphologyEx(opened, cv2.MORPH_CLOSE, kernel, iterations=close_iterations)
+
+    contours, _ = cv2.findContours(processed, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    bboxes: list[tuple[int, int, int, int]] = []
+    for contour in contours:
+        x, y, w, h = cv2.boundingRect(contour)
+        if w * h >= min_area:
+            bboxes.append((int(x), int(y), int(w), int(h)))
+
+    return sorted(bboxes, key=lambda box: (box[1], box[0]))
+
+
+def gaps_from_bboxes(
+    bboxes: Iterable[tuple[int, int, int, int]],
+    *,
+    axis_tolerance: int = 2,
+    min_overlap_ratio: float = 0.3,
+) -> tuple[list[int], list[int]]:
+    """Compute horizontal and vertical gaps between neighboring boxes."""
+
+    boxes = list(bboxes)
+    if len(boxes) < 2:
+        return [], []
+
+    def _overlap(start1: int, end1: int, start2: int, end2: int) -> int:
+        return min(end1, end2) - max(start1, start2)
+
+    def _dedupe(values: list[int]) -> list[int]:
+        if not values:
+            return []
+        values.sort()
+        merged = [values[0]]
+        for gap in values[1:]:
+            if abs(gap - merged[-1]) <= axis_tolerance:
+                merged[-1] = int(round((merged[-1] + gap) / 2))
+            else:
+                merged.append(gap)
+        return merged
+
+    horizontal: list[int] = []
+    vertical: list[int] = []
+
+    sorted_x = sorted(boxes, key=lambda b: b[0])
+    for idx, a in enumerate(sorted_x):
+        ax1, ay1, aw, ah = a
+        ax2 = ax1 + aw
+        ay2 = ay1 + ah
+        for b in sorted_x[idx + 1 :]:
+            bx1, by1, bw, bh = b
+            bx2 = bx1 + bw
+            by2 = by1 + bh
+            overlap = _overlap(ay1, ay2, by1, by2)
+            min_height = min(ah, bh)
+            if min_height <= 0:
+                continue
+            if overlap / min_height < min_overlap_ratio:
+                continue
+            gap = bx1 - ax2
+            if gap > 0:
+                horizontal.append(gap)
+                break
+
+    sorted_y = sorted(boxes, key=lambda b: b[1])
+    for idx, a in enumerate(sorted_y):
+        ax1, ay1, aw, ah = a
+        ax2 = ax1 + aw
+        ay2 = ay1 + ah
+        for b in sorted_y[idx + 1 :]:
+            bx1, by1, bw, bh = b
+            bx2 = bx1 + bw
+            by2 = by1 + bh
+            overlap = _overlap(ax1, ax2, bx1, bx2)
+            min_width = min(aw, bw)
+            if min_width <= 0:
+                continue
+            if overlap / min_width < min_overlap_ratio:
+                continue
+            gap = by1 - ay2
+            if gap > 0:
+                vertical.append(gap)
+                break
+
+    return _dedupe(horizontal), _dedupe(vertical)

--- a/tests/unit/application/test_gap_extraction.py
+++ b/tests/unit/application/test_gap_extraction.py
@@ -1,0 +1,35 @@
+import cv2
+import numpy as np
+
+from cv_pipeline.primitives import components_to_bboxes, gaps_from_bboxes
+
+
+def make_test_image() -> np.ndarray:
+    canvas = np.full((140, 220), 255, dtype=np.uint8)
+    cv2.rectangle(canvas, (10, 20), (70, 100), 0, -1)
+    cv2.rectangle(canvas, (90, 30), (140, 95), 30, -1)
+    cv2.rectangle(canvas, (160, 40), (210, 120), 0, -1)
+    return canvas
+
+
+def test_components_to_bboxes_detects_blocks():
+    gray = make_test_image()
+    boxes = components_to_bboxes(gray, min_area=200)
+    assert len(boxes) == 3
+    xs = [box[0] for box in boxes]
+    assert xs == sorted(xs)
+    widths = [box[2] for box in boxes]
+    assert all(w > 30 for w in widths)
+
+
+def test_gaps_from_bboxes_merges_near_values():
+    bboxes = [
+        (0, 0, 40, 40),
+        (70, 0, 30, 42),
+        (140, 2, 30, 38),
+        (10, 90, 36, 30),
+        (15, 150, 36, 32),
+    ]
+    x_gaps, y_gaps = gaps_from_bboxes(bboxes, axis_tolerance=3)
+    assert x_gaps == [30, 40]
+    assert y_gaps == [30, 50]

--- a/tests/unit/application/test_grid_detection.py
+++ b/tests/unit/application/test_grid_detection.py
@@ -1,0 +1,16 @@
+from copy_that.application.cv.grid_cv_extractor import infer_grid_from_bboxes
+
+
+def test_infer_grid_from_bboxes_detects_columns():
+    boxes = [
+        (10, 10, 40, 30),
+        (20, 60, 40, 30),
+        (110, 12, 38, 35),
+        (120, 70, 36, 32),
+        (210, 18, 34, 30),
+    ]
+    result = infer_grid_from_bboxes(boxes, canvas_width=320, tolerance_ratio=0.1)
+    assert result is not None
+    assert result["columns"] == 3
+    assert result["gutter_px"] > 0
+    assert result["margin_left"] >= 0

--- a/tests/unit/application/test_spacing_base_inference.py
+++ b/tests/unit/application/test_spacing_base_inference.py
@@ -1,0 +1,24 @@
+import pytest
+
+from copy_that.application import spacing_utils as su
+
+
+def test_infer_base_spacing_robust_identifies_eight_point_grid():
+    base, confidence, normalized = su.infer_base_spacing_robust([8, 16, 24, 32])
+    assert base == 8
+    assert confidence == pytest.approx(1.0)
+    assert normalized == [8, 16, 24, 32]
+
+
+def test_infer_base_spacing_robust_handles_noisy_values():
+    base, confidence, normalized = su.infer_base_spacing_robust([8, 9, 16, 17, 30])
+    assert base == 8
+    assert 0.7 < confidence < 1.0
+    assert normalized == [8, 16, 32]
+
+
+def test_infer_base_spacing_robust_penalizes_unit_grids():
+    base, confidence, normalized = su.infer_base_spacing_robust([8, 12, 20, 34, 47])
+    assert base == 4
+    assert confidence == pytest.approx(0.816, rel=1e-3)
+    assert normalized[-1] >= normalized[0]

--- a/tests/unit/application/test_spacing_cv_extractor.py
+++ b/tests/unit/application/test_spacing_cv_extractor.py
@@ -12,3 +12,71 @@ def test_cvspacing_fallback_without_opencv(monkeypatch):
     assert result.tokens  # fallback tokens exist
     assert result.base_unit == 4
     assert result.scale_system == "4pt"
+
+
+def test_cvspacing_detects_baseline_token(monkeypatch):
+    class DummyGray:
+        shape = (120, 320)
+
+    dummy_gray = DummyGray()
+    monkeypatch.setattr(
+        spacing_cv_extractor, "preprocess_image", lambda data: {"cv_gray": dummy_gray}
+    )
+    monkeypatch.setattr(
+        spacing_cv_extractor,
+        "components_to_bboxes",
+        lambda gray: [(0, 0, 30, 10), (10, 20, 36, 12), (6, 40, 34, 10), (5, 60, 30, 10)],
+    )
+    monkeypatch.setattr(
+        spacing_cv_extractor,
+        "gaps_from_bboxes",
+        lambda bboxes, **kwargs: ([8, 16, 24], []),
+    )
+    extractor = CVSpacingExtractor(max_tokens=4)
+    result = extractor.extract_from_bytes(b"raw")
+    baseline_tokens = [t for t in result.tokens if t.name == "spacing-baseline"]
+    assert baseline_tokens, "baseline token should be present"
+    assert result.baseline_spacing is not None
+    assert result.baseline_spacing["value_px"] == baseline_tokens[0].value_px
+
+
+def test_cvspacing_component_metrics_and_grid(monkeypatch):
+    class DummyGray:
+        shape = (200, 360)
+
+    dummy_gray = DummyGray()
+    monkeypatch.setattr(
+        spacing_cv_extractor, "preprocess_image", lambda data: {"cv_gray": dummy_gray}
+    )
+    boxes = [
+        (0, 0, 80, 60),
+        (10, 10, 50, 20),
+        (100, 0, 80, 60),
+        (110, 12, 40, 22),
+        (210, 0, 80, 60),
+        (220, 12, 40, 22),
+    ]
+    monkeypatch.setattr(spacing_cv_extractor, "components_to_bboxes", lambda gray: boxes)
+    monkeypatch.setattr(
+        spacing_cv_extractor,
+        "gaps_from_bboxes",
+        lambda bboxes, **kwargs: ([12, 18, 24], [20]),
+    )
+    monkeypatch.setattr(
+        spacing_cv_extractor,
+        "infer_grid_from_bboxes",
+        lambda bboxes, canvas_width: {
+            "columns": 3,
+            "gutter_px": 20,
+            "margin_left": 12,
+            "margin_right": 18,
+            "confidence": 0.8,
+        },
+    )
+    extractor = CVSpacingExtractor(max_tokens=4)
+    result = extractor.extract_from_bytes(b"bytes")
+    assert result.component_spacing_metrics
+    first = result.component_spacing_metrics[0]
+    assert first["padding"]["left"] > 0
+    assert result.grid_detection is not None
+    assert result.grid_detection["columns"] == 3

--- a/tests/unit/application/test_spacing_utils.py
+++ b/tests/unit/application/test_spacing_utils.py
@@ -35,3 +35,22 @@ def test_infer_base_spacing_high_confidence():
     base, confidence = su.infer_base_spacing([8, 16, 8, 24, 16])
     assert base == 8
     assert confidence >= 0.8
+
+
+def test_detect_baseline_spacing_from_bboxes_success():
+    bboxes = [
+        (0, 0, 40, 10),
+        (50, 20, 38, 12),
+        (10, 40, 36, 14),
+        (70, 60, 30, 10),
+    ]
+    spacing = su.detect_baseline_spacing_from_bboxes(bboxes)
+    assert spacing is not None
+    value, confidence = spacing
+    assert abs(value - 20) <= 2
+    assert confidence > 0.4
+
+
+def test_detect_baseline_spacing_from_bboxes_insufficient_pairs():
+    spacing = su.detect_baseline_spacing_from_bboxes([(0, 0, 40, 10), (40, 4, 20, 10)], min_pairs=3)
+    assert spacing is None


### PR DESCRIPTION
**Summary**

- Add CV-based spacing pipeline: bboxes/gap extraction, robust base-unit inference with diagnostics, baseline rhythm, padding/margin heuristics, and grid detection (columns/gutter/margins). Wire results through spacing service/API and reference gutter/margin spacing tokens in W3C export.
- Introduce grid inference utility and new spacing tests (base inference, grid detection, spacing CV).
- Enhance color CV extractor with k-means segmentation palette, and stream it in SSE debug payloads.
- Update frontend: spacing panel shows base/grid/baseline/padding diagnostics; color panel renders segmented coverage; uploader triggers all token extractions. Added types/styles for new data.
