### PR TITLE
Harden typography recommendation metadata and frontend rendering

### DIFF
--- a/frontend/src/components/TypographyInspector.tsx
+++ b/frontend/src/components/TypographyInspector.tsx
@@ -7,6 +7,8 @@ export default function TypographyInspector() {
   const typography = useTokenGraphStore((s) => s.typography)
   const colors = useTokenGraphStore((s) => s.colors)
   const recommendation = useTokenGraphStore((s) => s.typographyRecommendation)
+  // Destructure recommendation to avoid repetitive optional chaining and to set defaults.
+  const { confidence, styleAttributes } = recommendation ?? {}
   if (!typography.length) return null
 
   const findColorHex = (id: string) => {
@@ -21,11 +23,14 @@ export default function TypographyInspector() {
       {recommendation && (
         <div className="meta-row">
           <span className="badge">
-            Confidence: {recommendation.confidence != null ? recommendation.confidence.toFixed(2) : '—'}
+            Confidence:{' '}
+            {typeof confidence === 'number' && !Number.isNaN(confidence)
+              ? confidence.toFixed(2)
+              : '—'}
           </span>
-          {recommendation.styleAttributes && (
+          {styleAttributes && (
             <code className="style-attrs">
-              {Object.entries(recommendation.styleAttributes)
+              {Object.entries(styleAttributes)
                 .map(([k, v]) => `${k}:${String(v)}`)
                 .join(' · ')}
             </code>

--- a/src/copy_that/interfaces/api/design_tokens.py
+++ b/src/copy_that/interfaces/api/design_tokens.py
@@ -149,10 +149,23 @@ async def export_design_tokens_w3c(
         repo.upsert_token(token)
 
     payload = tokens_to_w3c(repo)
+    # Sanitize recommendation fields to avoid propagating unexpected types.
+    confidence_raw = recommendation.get("confidence")
+    confidence: float | None
+    if isinstance(confidence_raw, (int, float)) and not math.isnan(confidence_raw):
+        confidence = float(confidence_raw)
+    else:
+        confidence = None
+    style_attrs_raw = recommendation.get("style_attributes")
+    style_attrs: StyleAttributes | dict[str, Any]
+    if isinstance(style_attrs_raw, dict):
+        style_attrs = style_attrs_raw
+    else:
+        style_attrs = {}
     payload["meta"] = {
         "typography_recommendation": {
-            "style_attributes": recommendation["style_attributes"],
-            "confidence": recommendation["confidence"],
+            "style_attributes": style_attrs,
+            "confidence": confidence,
         }
     }
 


### PR DESCRIPTION
**Summary**

- Tighten design-tokens export: sanitize recommendation confidence/style attributes and expose them under meta.typography_recommendation.
- Relax frontend graph store parsing to handle missing/nullable recommendation fields; accept legacy alias/multipleOf shapes robustly.
- Typography inspector now renders confidence safely and displays style attributes with defaults.

**Tests**

- pytest tests/unit/api/test_w3c_export_contracts.py
- mypy src
- cd frontend && pnpm test --run TypographyInspector
- Pre-commit hooks (ruff/format, EOF/whitespace)